### PR TITLE
fix: add missing root link in /collections

### DIFF
--- a/stac_fastapi/eodag/core.py
+++ b/stac_fastapi/eodag/core.py
@@ -46,6 +46,7 @@ from eodag import SearchResult
 from eodag.api.core import DEFAULT_ITEMS_PER_PAGE
 from eodag.utils import deepcopy
 from eodag.utils.exceptions import NoMatchingProductType
+from stac_fastapi.eodag.config import get_settings
 from stac_fastapi.eodag.cql_evaluate import EodagEvaluator
 from stac_fastapi.eodag.errors import ResponseSearchError
 from stac_fastapi.eodag.landing_page import CustomCoreClient
@@ -263,7 +264,13 @@ class EodagCoreClient(CustomCoreClient):
                 "rel": Relations.self.value,
                 "type": MimeTypes.json,
                 "href": urljoin(base_url, "collections"),
-                "title": "Collection",
+                "title": "Collections",
+            },
+            {
+                "rel": Relations.root,
+                "type": MimeTypes.json,
+                "href": base_url,
+                "title": get_settings().stac_fastapi_title,
             },
         ]
         return Collections(collections=collections or [], links=links)


### PR DESCRIPTION
/collections is not included in CEOS recommendation CEOS-STAC-REC-3420.

> Implementations should not use the rel="root" relation in STAC collection and item encodings as the original catalog/collections may be referenced or included in a federated catalog with a different root.

In addition, it is considered **required** according to [STAC API - Collections and Features Specification](https://github.com/radiantearth/stac-api-spec/tree/release/v1.0.0/ogcapi-features#collections-collections).