### PR TITLE
fix: take 'page' param into account during GET mode search

### DIFF
--- a/stac_fastapi/eodag/extensions/pagination.py
+++ b/stac_fastapi/eodag/extensions/pagination.py
@@ -33,11 +33,11 @@ class POSTPagination(BaseModel):
     page: int = 1
 
 
-@dataclass
+@attr.s
 class GETPagination(APIRequest):
     """Page based pagination for GET requests."""
 
-    page: Annotated[int, Query()] = 1
+    page: Annotated[int, Query(description="Returns results of this page")] = attr.ib(default=1)
 
 
 @attr.s


### PR DESCRIPTION
Fixes this [issue](https://gitlab.si.c-s.fr/dedl/tasks/-/issues/268)

`page` parameter is now taken into account during a `GET` mode search by using `attr` library instead of `dataclass` to create the class `GETPagination`. That also make this parameter visible in the `GET` search endpoint of the swagger.