### PR TITLE
build: update dev optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ telemetry = [
     "opentelemetry-instrumentation-fastapi"
 ]
 dev = [
+    "stac_fastapi.eodag[server,telemetry]",
     "geojson",
     "httpx",
     "importlib-metadata",


### PR DESCRIPTION
Includes `server` and `telemetry` optional dependecies into `stac_fastapi.eodag[dev]`.

Updates #13 