### PR TITLE
fix: empty body

### DIFF
--- a/stac_fastapi/eodag/config.py
+++ b/stac_fastapi/eodag/config.py
@@ -31,6 +31,7 @@ from stac_fastapi.eodag.utils import str2liststr
 
 class Settings(ApiSettings):
     """EODAG Server config"""
+
     debug: bool = False
 
     keep_origin_url: bool = Field(

--- a/stac_fastapi/eodag/extensions/pagination.py
+++ b/stac_fastapi/eodag/extensions/pagination.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 """Pagination extension. Override to default page to 1."""
 
-from dataclasses import dataclass
 from typing import Annotated
 
 import attr

--- a/stac_fastapi/eodag/models/links.py
+++ b/stac_fastapi/eodag/models/links.py
@@ -286,11 +286,14 @@ class ItemLinks(CollectionLinksBase):
     def collection_order_extension_link_retrieve(self) -> Optional[dict[str, Any]]:
         """Create the `retrieve` link."""
         href = self.resolve(f"collections/{self.collection_id}/order")
-        return {
+        link = {
             "rel": "retrieve",
             "type": MimeTypes.geojson.value,
             "href": href,
             "method": "POST",
-            "body": self.retrieve_body or {},
             "title": "Retrieve",
         }
+        if self.retrieve_body:
+            link["body"] = self.retrieve_body
+
+        return link


### PR DESCRIPTION
For items that need to be ordered, we provide a retrieve link using a POST request with a body to place the order.
This PR removes the body when it's empty.
The POST request can now be made without a body when it's not needed.