### PR TITLE
build: add env var for otel collector in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - stacapi-eodag-network
     depends_on:
       - otel-collector
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318/"
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.90.1
     container_name: otel_collector


### PR DESCRIPTION
adds the environment variable for the otel collector endpoint to the docker compose to ensure that metrics are sent