### PR TITLE
Wekeo main order

### DIFF
--- a/stac_fastapi/eodag/config.py
+++ b/stac_fastapi/eodag/config.py
@@ -43,6 +43,11 @@ class Settings(ApiSettings):
         description=("Hide from clients items assets' origin URLs starting with URLs from the list"),
     )
 
+    auto_order_whitelist: Annotated[Union[str, list[str]], BeforeValidator(str2liststr)] = Field(
+        default=["wekeo_main",],
+        description=("Do the order at the same time as the download"),
+    )
+
     fetch_providers: bool = Field(default=False, description="Fetch additional collections from all providers.")
 
     download_base_url: str = Field(

--- a/stac_fastapi/eodag/config.py
+++ b/stac_fastapi/eodag/config.py
@@ -44,7 +44,9 @@ class Settings(ApiSettings):
     )
 
     auto_order_whitelist: Annotated[Union[str, list[str]], BeforeValidator(str2liststr)] = Field(
-        default=["wekeo_main",],
+        default=[
+            "wekeo_main",
+        ],
         description=("Do the order at the same time as the download"),
     )
 

--- a/stac_fastapi/eodag/extensions/data_download.py
+++ b/stac_fastapi/eodag/extensions/data_download.py
@@ -34,6 +34,7 @@ from stac_fastapi.api.errors import NotFoundError
 from stac_fastapi.api.routes import create_async_endpoint
 from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.search import APIRequest
+from stac_fastapi.eodag.config import get_settings 
 
 from stac_fastapi.eodag.errors import (
     DownloadError,
@@ -119,6 +120,30 @@ class BaseDataDownloadClient:
                 f"Could not find {item_id} item in {product_type} collection",
                 f" for backend {federation_backend}.",
             )
+        
+
+        settings = get_settings()
+        whitelist = settings.auto_order_whitelist
+        if federation_backend in whitelist:
+            logger.info(f"Provider {federation_backend} is whitelisted, ordering product before download")
+                        # "title" property is a fake one create by EODAG, set it to the item ID
+           
+
+            auth = product.downloader_auth.authenticate() if product.downloader_auth else None
+
+            logger.debug("Poll product")
+            try:
+                product.downloader.order(product=product, auth=auth)
+            # when a NotAvailableError is catched, it means the product is not ready and still needs to be polled
+            except NotAvailableError as e :
+                product.properties["storageStatus"] = STAGING_STATUS
+                
+            except Exception as e:
+                if (
+                    isinstance(e, DownloadError) or isinstance(e, ValidationError)
+                ) and "order status could not be checked" in e.args[0]:
+                    raise NotFoundError(f"Item {item_id} does not exist. Please order it first") from e
+                raise NotFoundError(e) from e
         auth = product.downloader_auth.authenticate() if product.downloader_auth else None
 
         if product.downloader is None:

--- a/stac_fastapi/eodag/extensions/data_download.py
+++ b/stac_fastapi/eodag/extensions/data_download.py
@@ -34,8 +34,8 @@ from stac_fastapi.api.errors import NotFoundError
 from stac_fastapi.api.routes import create_async_endpoint
 from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.search import APIRequest
-from stac_fastapi.eodag.config import get_settings 
 
+from stac_fastapi.eodag.config import get_settings
 from stac_fastapi.eodag.errors import (
     DownloadError,
     MisconfiguredError,
@@ -120,30 +120,26 @@ class BaseDataDownloadClient:
                 f"Could not find {item_id} item in {product_type} collection",
                 f" for backend {federation_backend}.",
             )
-        
 
         settings = get_settings()
         whitelist = settings.auto_order_whitelist
         if federation_backend in whitelist:
             logger.info(f"Provider {federation_backend} is whitelisted, ordering product before download")
-                        # "title" property is a fake one create by EODAG, set it to the item ID
-           
 
             auth = product.downloader_auth.authenticate() if product.downloader_auth else None
-
             logger.debug("Poll product")
             try:
                 product.downloader.order(product=product, auth=auth)
             # when a NotAvailableError is catched, it means the product is not ready and still needs to be polled
-            except NotAvailableError as e :
+            except NotAvailableError:
                 product.properties["storageStatus"] = STAGING_STATUS
-                
             except Exception as e:
                 if (
                     isinstance(e, DownloadError) or isinstance(e, ValidationError)
                 ) and "order status could not be checked" in e.args[0]:
                     raise NotFoundError(f"Item {item_id} does not exist. Please order it first") from e
                 raise NotFoundError(e) from e
+
         auth = product.downloader_auth.authenticate() if product.downloader_auth else None
 
         if product.downloader is None:

--- a/stac_fastapi/eodag/models/stac_metadata.py
+++ b/stac_fastapi/eodag/models/stac_metadata.py
@@ -52,7 +52,6 @@ from stac_fastapi.eodag.extensions.stac import (
     BaseStacExtension,
 )
 from stac_fastapi.eodag.models.links import ItemLinks
-from stac_fastapi.eodag.config import get_settings 
 
 
 class CommonStacMetadata(ItemProperties):


### PR DESCRIPTION
This PR aims to fix the order/download for the wekeo_main provider.

The wekeo_main provider requires an order to be placed immediately before downloading. To handle this, I introduced an auto_order_whitelist. For any provider in this list (currently only wekeo_main), we skip showing the order link, even if the product is offline, and directly provide the download link.

This fixes the issue with empty order request bodies. Now, when we attempt to download a collection, the order is placed automatically just before the download.

This PR is linked to another one on the EODAG project to fix the _order_download_retry mechanism.