### PR TITLE
feat(core): set count search parameter to its value in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Reach to [stac-fastapi documentation](https://stac-utils.github.io/stac-fastapi/
 | `DEBUG` | When set to `True`, set the EODAG logging level to `3`. Otherwise, set EODAG logging level to `2`. | False |
 | `KEEP_ORIGIN_URL` | Keep origin as alternate URL when data-download extension is enabled. | False |
 | `ORIGIN_URL_BLACKLIST` | Hide from clients items assets' origin URLs starting with URLs from the list. A string of comma separated values is expected. | "" |
+| `COUNT` | Whether to run a query with a count request or not. | False |
 | `FETCH_PROVIDERS` | Fetch additional collections from all EODAG providers. | False |
 | `DOWNLOAD_BASE_URL` | Useful to expose asset download URL in a separate domain name. | "" |
 

--- a/stac_fastapi/eodag/config.py
+++ b/stac_fastapi/eodag/config.py
@@ -52,6 +52,11 @@ class Settings(ApiSettings):
 
     fetch_providers: bool = Field(default=False, description="Fetch additional collections from all providers.")
 
+    count: bool = Field(
+        default=False,
+        description=("Whether to run a query with a count request or not"),
+    )
+
     download_base_url: str = Field(
         default="",
         description="base url to be used for download link",

--- a/stac_fastapi/eodag/core.py
+++ b/stac_fastapi/eodag/core.py
@@ -520,7 +520,7 @@ def prepare_search_base_args(search_request: BaseSearchPostRequest, model: type[
             "page": search_request.page,
             "items_per_page": search_request.limit,
             "raise_errors": False,
-            "count": True,
+            "count": get_settings().count,
         }
         if search_request.ids is None
         else {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,7 +266,7 @@ def mock_search_result():
     for p in search_result:
         p.downloader = Download("peps", config)
         p.downloader_auth = Authentication("peps", config)
-    search_result.number_matched = len(search_result)
+    search_result.number_matched = None
     return search_result
 
 
@@ -449,6 +449,7 @@ def assert_links_valid(app_client, request_valid_raw, request_not_valid):
         known_rel = [
             "self",
             "root",
+            "next",
             "child",
             "items",
             "service-desc",

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -282,7 +282,7 @@ async def test_order_product_wrong_downloader_ko(request_not_found, mock_search,
     assert "No downloader available" in caplog.messages[0]
 
     # try to order a product which has a downloader but without order() method
-    dl_config = config.PluginConfig.from_mapping({"priority": 1})
+    dl_config = config.PluginConfig.from_mapping({"type": "HTTPDownload", "priority": 1})
     product.downloader = Download(federation_backend, dl_config)
     assert not hasattr(product.downloader, "order")
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -53,13 +53,15 @@ async def test_request_params_valid(request_valid, defaults, input_bbox, expecte
         ),
     )
 
+
 async def test_count_search(request_valid, defaults, mock_search, mock_search_result):
     """
     Test the count setting during a search.
     """
+    count = get_settings().count
     qs = f"search?collections={defaults.product_type}"
 
-    assert get_settings().count is False, "Default count setting should be False"
+    assert count is False, "Default count setting should be False"
     response = await request_valid(
         qs,
         expected_search_kwargs=dict(
@@ -90,6 +92,9 @@ async def test_count_search(request_valid, defaults, mock_search, mock_search_re
         ),
     )
     assert response["numberMatched"] == 2
+
+    # Reset count setting to default
+    get_settings().count = count
 
 
 async def test_items_response(request_valid, defaults):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -48,10 +48,48 @@ async def test_request_params_valid(request_valid, defaults, input_bbox, expecte
             page=1,
             items_per_page=DEFAULT_ITEMS_PER_PAGE,
             raise_errors=False,
-            count=True,
+            count=False,
             **expected_kwargs,
         ),
     )
+
+async def test_count_search(request_valid, defaults, mock_search, mock_search_result):
+    """
+    Test the count setting during a search.
+    """
+    qs = f"search?collections={defaults.product_type}"
+
+    assert get_settings().count is False, "Default count setting should be False"
+    response = await request_valid(
+        qs,
+        expected_search_kwargs=dict(
+            productType=defaults.product_type,
+            page=1,
+            items_per_page=DEFAULT_ITEMS_PER_PAGE,
+            raise_errors=False,
+            count=False,  # Ensure count is set to False
+        ),
+    )
+    assert response["numberMatched"] is None
+
+    # Reset search mock, set "number_matched" attribute of the search results mock for a counting search
+    # and set count to True
+    mock_search.reset_mock()
+    search_result = mock_search_result
+    search_result.number_matched = len(search_result)
+    get_settings().count = True
+
+    response = await request_valid(
+        qs,
+        expected_search_kwargs=dict(
+            productType=defaults.product_type,
+            page=1,
+            items_per_page=DEFAULT_ITEMS_PER_PAGE,
+            raise_errors=False,
+            count=True,  # Ensure count is set to True
+        ),
+    )
+    assert response["numberMatched"] == 2
 
 
 async def test_items_response(request_valid, defaults):
@@ -193,7 +231,7 @@ async def test_date_search(request_valid, defaults, input_start, input_end, expe
             items_per_page=DEFAULT_ITEMS_PER_PAGE,
             geom=defaults.bbox_wkt,
             raise_errors=False,
-            count=True,
+            count=False,
             **expected_kwargs,
         ),
     )
@@ -213,7 +251,7 @@ async def test_date_search_from_items(request_valid, defaults, use_dates):
             items_per_page=DEFAULT_ITEMS_PER_PAGE,
             geom=defaults.bbox_wkt,
             raise_errors=False,
-            count=True,
+            count=False,
             **expected_kwargs,
         ),
     )
@@ -240,7 +278,7 @@ async def test_sortby_items_parametrize(request_valid, defaults, sortby, expecte
             "page": 1,
             "items_per_page": 10,
             "raise_errors": False,
-            "count": True,
+            "count": False,
         },
         check_links=False,
     )
@@ -285,7 +323,7 @@ async def test_cloud_cover_post_search(request_valid, defaults):
             cloudCover=10,
             geom=defaults.bbox_wkt,
             raise_errors=False,
-            count=True,
+            count=False,
         ),
     )
 
@@ -305,7 +343,7 @@ async def test_intersects_post_search(request_valid, defaults):
             items_per_page=DEFAULT_ITEMS_PER_PAGE,
             geom=defaults.bbox_wkt,
             raise_errors=False,
-            count=True,
+            count=False,
         ),
     )
 
@@ -339,7 +377,7 @@ async def test_date_post_search(request_valid, defaults, input_start, input_end,
             page=1,
             items_per_page=DEFAULT_ITEMS_PER_PAGE,
             raise_errors=False,
-            count=True,
+            count=False,
             **expected_kwargs,
         ),
     )
@@ -464,7 +502,7 @@ async def test_search_provider_in_downloadlink(request_valid, defaults, method, 
             page=1,
             items_per_page=10,
             raise_errors=False,
-            count=True,
+            count=False,
             productType=defaults.product_type,
             **expected_kwargs,
         ),


### PR DESCRIPTION
This PR allows to run a query with a count request or not by setting `COUNT` parameter. By default, its value is `False`.