### PR TITLE
feat: redirect to pre-signed url

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ from eodag.plugins.authentication.base import Authentication
 from eodag.plugins.authentication.openid_connect import OIDCRefreshTokenBase
 from eodag.plugins.authentication.token import TokenAuth
 from eodag.plugins.authentication.token_exchange import OIDCTokenExchangeAuth
+from eodag.plugins.download.aws import AwsDownload
 from eodag.plugins.download.base import Download
 from eodag.plugins.download.http import HTTPDownload
 from eodag.plugins.search.qssearch import StacSearch
@@ -337,7 +338,7 @@ def mock_http_base_stream_download_dict(mocker):
 @pytest.fixture(scope="function")
 def mock_order(mocker):
     """
-    Mocks the `HTTPDownload` method of the `HTTPDownload` download plugin.
+    Mocks the `order` method of the `HTTPDownload` download plugin.
     """
     return mocker.patch.object(HTTPDownload, "order")
 
@@ -396,6 +397,7 @@ def request_valid_raw(app_client, mock_search, mock_search_result):
         search_call_count: Optional[int] = None,
         search_result: Optional[SearchResult] = None,
         expected_status_code: int = 200,
+        follow_redirects: bool = True,
     ):
         if search_result:
             mock_search.return_value = search_result
@@ -406,7 +408,7 @@ def request_valid_raw(app_client, mock_search, mock_search_result):
             method,
             url,
             json=post_data,
-            follow_redirects=True,
+            follow_redirects=follow_redirects,
             headers={"Content-Type": "application/json"} if method == "POST" else {},
         )
 
@@ -584,6 +586,12 @@ def request_accepted(app_client):
         return response_content
 
     return _request_accepted
+
+
+@pytest.fixture(scope="function")
+def mock_presign_url(mocker):
+    """Fixture for the presign_url function"""
+    return mocker.patch.object(AwsDownload, "presign_url")
 
 
 @dataclass

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -22,6 +22,7 @@ import os
 from eodag import SearchResult
 from eodag.api.product import EOProduct
 from eodag.config import PluginConfig
+from eodag.plugins.download.aws import AwsDownload
 from eodag.plugins.download.http import HTTPDownload
 
 from stac_fastapi.eodag.config import get_settings
@@ -104,3 +105,34 @@ async def test_download_auto_order_whitelist(
 
     # restore the original auto_order_whitelist setting
     get_settings().auto_order_whitelist = auto_order_whitelist
+
+
+async def test_download_redirect_response(request_valid_raw, mock_search, mock_presign_url, mock_base_authenticate):
+    """test that a reponse with status code 302 is returned if presigned urls are used"""
+    product_type = "MO_GLOBAL_ANALYSISFORECAST_PHY_001_024"
+    product = EOProduct(
+        "cop_marine",
+        dict(
+            geometry="POINT (0 0)",
+            title="dummy_product",
+            id="dummy",
+        ),
+        productType=product_type,
+    )
+    product.assets.update({"a1": {"href": "https://s3.waw3-1.cloudferro.com/b1/a1/a1.json"}})
+    product.assets.update({"a2": {"href": "https://s3.waw3-1.cloudferro.com/b1/a2/a2.json"}})
+
+    config = PluginConfig()
+    config.priority = 0
+    downloader = AwsDownload("cop_marine", config)
+    product.register_downloader(downloader=downloader, authenticator=None)
+    mock_search.return_value = SearchResult([product])
+
+    mock_presign_url.return_value = "s3://s3.abc.com/a1/b1?AWSAccesskeyId=123&expires=1543649"
+
+    await request_valid_raw(
+        f"data/cop_marine/{product_type}/foo/a1",
+        search_result=SearchResult([product]),
+        expected_status_code=302,
+        follow_redirects=False,
+    )


### PR DESCRIPTION
If only one asset is download, we attempt to create a pre-signed url. If this is successful, a `RedirectResponse` is returned instead of calling the `_stream_download_dict` method.