### PR TITLE
fix: make datetime filter work again on /collections

### DIFF
--- a/stac_fastapi/eodag/core.py
+++ b/stac_fastapi/eodag/core.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import unquote_plus
 
@@ -76,7 +75,6 @@ if TYPE_CHECKING:
 
     from fastapi import Request
     from pydantic import BaseModel
-    from stac_fastapi.types.rfc3339 import DateTimeType
 
     from eodag.api.product._product import EOProduct
 
@@ -356,7 +354,7 @@ class EodagCoreClient(CustomCoreClient):
         collection_id: str,
         request: Request,
         bbox: Optional[list[NumType]] = None,
-        datetime: Optional[Union[str, datetime]] = None,
+        datetime: Optional[str] = None,
         limit: Optional[int] = None,
         page: Optional[str] = None,
         sortby: Optional[list[str]] = None,
@@ -423,7 +421,7 @@ class EodagCoreClient(CustomCoreClient):
         collections: Optional[list[str]] = None,
         ids: Optional[list[str]] = None,
         bbox: Optional[list[NumType]] = None,
-        datetime: Optional[DateTimeType] = None,
+        datetime: Optional[str] = None,
         limit: Optional[int] = None,
         query: Optional[str] = None,
         page: Optional[str] = None,

--- a/stac_fastapi/eodag/core.py
+++ b/stac_fastapi/eodag/core.py
@@ -37,6 +37,7 @@ from pygeofilter.parsers.cql2_json import parse as parse_json
 from pygeofilter.parsers.cql2_text import parse as parse_cql2_text
 from stac_fastapi.types.errors import NotFoundError
 from stac_fastapi.types.requests import get_base_url
+from stac_fastapi.types.rfc3339 import str_to_interval
 from stac_fastapi.types.search import BaseSearchPostRequest
 from stac_fastapi.types.stac import Collection, Collections, Item, ItemCollection
 from stac_pydantic.links import Relations
@@ -222,7 +223,7 @@ class EodagCoreClient(CustomCoreClient):
         self,
         request: Request,
         bbox: Optional[list[NumType]] = None,
-        datetime: Optional[DateTimeType] = None,
+        datetime: Optional[str] = None,
         limit: Optional[int] = 10,
         offset: Optional[int] = 0,
         q: Optional[str] = None,
@@ -259,7 +260,7 @@ class EodagCoreClient(CustomCoreClient):
 
         # datetime & free-text-search filters
         if any((q, datetime)):
-            start, end = dt_range_to_eodag(datetime)
+            start, end = dt_range_to_eodag(str_to_interval(datetime))
 
             try:
                 guessed_product_types = request.app.state.dag.guess_product_type(

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -127,6 +127,30 @@ async def test_search_collections_bbox(app_client, mock_list_product_types, mock
     assert ["S2_MSI_L1C", "S1_SAR_GRD"] == [col["id"] for col in r.json().get("collections", [])]
 
 
+async def test_search_collections_datetime(app_client, mock_list_product_types, mock_guess_product_type):
+    """A collections datetime search must succeed"""
+    mock_list_product_types.return_value = [
+        {
+            "_id": "S2_MSI_L1C",
+            "ID": "S2_MSI_L1C",
+            "title": "SENTINEL2 Level-1C",
+            "missionStartDate": "2015-06-23T00:00:00Z",
+        },
+        {"_id": "S2_MSI_L2A", "ID": "S2_MSI_L2A"},
+    ]
+    mock_guess_product_type.return_value = ["S2_MSI_L1C"]
+
+    start = "2014-01-01T00:00:00Z"
+    end = "2016-01-01T00:00:00Z"
+
+    r = await app_client.get(f"/collections?datetime={start}/{end}")
+
+    assert mock_list_product_types.called
+    mock_guess_product_type.assert_called_once_with(free_text=None, missionStartDate=start, missionEndDate=end)
+    assert r.status_code == 200
+    assert ["S2_MSI_L1C"] == [col["id"] for col in r.json().get("collections", [])]
+
+
 async def test_collections_pagination_default_and_custom_limits(app_client, mock_list_product_types):
     """
     Test pagination behavior for collections with default and custom limits.


### PR DESCRIPTION
On `/collections` endpoint, the `datetime` filter made the request fail.

It fixes by the given input type from `str` to the type required by the processing.