### PR TITLE
refactor: whoosh removed from eodag

### DIFF
--- a/stac_fastapi/eodag/dag.py
+++ b/stac_fastapi/eodag/dag.py
@@ -23,7 +23,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from eodag import EODataAccessGateway
-from eodag.utils import obj_md5sum
 from eodag.utils.exceptions import (
     RequestError,
     TimeOutError,
@@ -116,10 +115,6 @@ def init_dag(app: FastAPI) -> None:
             }
             clean = {k: v for k, v in update_fields.items() if v is not None}
             p_f.update(clean)
-
-    dag.product_types_config_md5 = obj_md5sum(dag.product_types_config.source)
-
-    dag.build_index()
 
     # pre-build search plugins
     for provider in dag.available_providers():

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -143,7 +143,6 @@ def fixture_mock_dag() -> MagicMock:
     mock_dag.product_types_config = MagicMock()
     # Set a default value for `product_types_config.source`
     mock_dag.product_types_config.source = {}
-    mock_dag.build_index = MagicMock()
     mock_dag._plugins_manager = MagicMock()  # pylint: disable=protected-access
     mock_dag._plugins_manager.get_search_plugins = MagicMock()  # pylint: disable=protected-access
     mock_dag.available_providers = MagicMock(return_value=["provider1", "provider2"])
@@ -246,9 +245,6 @@ def test_init_dag(
     # Assert: Verify that `dag.product_types_config.source` was updated
     updated_config = mock_dag.product_types_config.source["test-product"]
     assert updated_config == expected_updated_config
-
-    # Assert: Verify that `dag.build_index` was called
-    mock_dag.build_index.assert_called_once()
 
     # Assert: Verify that `dag._plugins_manager.get_search_plugins` was called for each provider
     mock_dag.available_providers.assert_called_once()


### PR DESCRIPTION
`whoosh` removed from `eodag`, see https://github.com/CS-SI/eodag/pull/1741