### PR TITLE
chore(helm): add hpa, terminationGracePeriodSeconds, deployment annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 stac-fastapi-eodag combines the capabilities of EODAG and STAC FastAPI to provide a powerful, unified API for accessing Earth observation data from various providers.
 
+**stac-fastapi-eodag is now available from GitHub: https://github.com/CS-SI/stac-fastapi-eodag. Please use the GitHub version instead.**
+
 ## Disclaimer
 
 ⚠️ This project is a **WIP** and not ready for any production usage. Use at your own risks.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 stac-fastapi-eodag combines the capabilities of EODAG and STAC FastAPI to provide a powerful, unified API for accessing Earth observation data from various providers.
 
-**stac-fastapi-eodag is now available from GitHub: https://github.com/CS-SI/stac-fastapi-eodag. Please use the GitHub version instead.**
-
 ## Disclaimer
 
 ⚠️ This project is a **WIP** and not ready for any production usage. Use at your own risks.

--- a/helm/stac-fastapi-eodag/Chart.lock
+++ b/helm/stac-fastapi-eodag/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-03-12T15:42:59.908620573+01:00"
+  version: 2.31.4
+digest: sha256:fc442e77200e1914dd46fe26490dcf62f44caa51db673c2f8e67d5319cd4c163
+generated: "2025-09-24T14:55:49.710744284+02:00"

--- a/helm/stac-fastapi-eodag/Chart.yaml
+++ b/helm/stac-fastapi-eodag/Chart.yaml
@@ -22,4 +22,4 @@ name: stac-fastapi-eodag
 sources:
   - https://github.com/CS-SI/stac-fastapi-eodag
 type: application
-version: 0.1.0
+version: 0.1.2

--- a/helm/stac-fastapi-eodag/Chart.yaml
+++ b/helm/stac-fastapi-eodag/Chart.yaml
@@ -22,4 +22,4 @@ name: stac-fastapi-eodag
 sources:
   - https://github.com/CS-SI/stac-fastapi-eodag
 type: application
-version: 0.1.2
+version: 0.3.0

--- a/helm/stac-fastapi-eodag/DEPLOYMENT.md
+++ b/helm/stac-fastapi-eodag/DEPLOYMENT.md
@@ -1,0 +1,62 @@
+# Deployment Guide for stac-fastapi-eodag
+
+This document provides guidance on deploying stac-fastapi-eodag in production environments, with specific focus on configuration management and graceful shutdowns.
+
+## Automatic Configuration Reloading with Reloader
+
+The stac-fastapi-eodag Helm chart supports automatic configuration reloading using [Reloader](https://github.com/stakater/Reloader). This allows pods to be automatically restarted when ConfigMaps or Secrets are updated.
+
+### Available Reloader Annotations
+
+| Annotation | Purpose | Example |
+|------------|---------|---------|
+| `configmap.reloader.stakater.com/reload` | Restart pods when specified ConfigMaps change | `"config-name1,config-name2"` |
+| `secret.reloader.stakater.com/reload` | Restart pods when specified Secrets change | `"secret-name1,secret-name2"` |
+| `reloader.stakater.com/auto` | Auto-discover and reload on any ConfigMap/Secret change | `"true"` |
+
+### Example Configuration
+
+```yaml
+# values.yaml
+deployment:
+  annotations:
+    # Reload when main config changes
+    configmap.reloader.stakater.com/reload: "stac-fastapi-eodag-config,data-repo-commit-hash"
+    # Reload when credentials change
+    secret.reloader.stakater.com/reload: "eodag-server-credentials"
+```
+
+### Installing Reloader
+
+If Reloader is not already installed in your cluster, you can install it using:
+
+```bash
+# Using Helm
+helm repo add stakater https://stakater.github.io/stakater-charts
+helm repo update
+helm install reloader stakater/reloader
+
+# Or using kubectl
+kubectl apply -f https://raw.githubusercontent.com/stakater/Reloader/master/deployments/kubernetes/reloader.yaml
+```
+
+## Graceful Shutdown with terminationGracePeriodSeconds
+
+The `terminationGracePeriodSeconds` parameter controls how long Kubernetes waits before forcefully killing a pod during shutdown. This is crucial for stac-fastapi-eodag when handling long-running operations like data downloads.
+
+### Configuring Termination Grace Period
+
+```yaml
+# values.yaml
+# Default Kubernetes value is 30 seconds
+terminationGracePeriodSeconds: 7200  # 2 hours for long downloads
+```
+
+### Troubleshooting
+
+If pods are being forcefully killed:
+
+1. **Increase Grace Period**: Adjust `terminationGracePeriodSeconds`
+2. **Check Application Logs**: Ensure the app handles SIGTERM
+3. **Monitor Resource Usage**: High CPU/memory might slow shutdown
+4. **Review Health Checks**: Ensure probes don't interfere with shutdown

--- a/helm/stac-fastapi-eodag/templates/deployment.yaml
+++ b/helm/stac-fastapi-eodag/templates/deployment.yaml
@@ -12,8 +12,14 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
+  {{- if or .Values.commonAnnotations .Values.deployment.annotations }}
+  annotations:
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.deployment.annotations }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.deployment.annotations "context" $) | nindent 4 }}
+  {{- end }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -76,6 +82,7 @@ spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/stac-fastapi-eodag/templates/horizontalpodautoscaler.yaml
+++ b/helm/stac-fastapi-eodag/templates/horizontalpodautoscaler.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.horizontalPodAutoscaler.enabled -}}
+  {{- if not .Values.resources.requests }}
+    {{- fail "resources.requests is required if horizontalPodAutoscaler is enabled" -}}
+  {{- end }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "common.names.fullname" . }}
+  minReplicas: {{ .Values.replicaCount }}
+  maxReplicas: {{ .Values.horizontalPodAutoscaler.maxReplicas }}
+  metrics:
+  {{- if .Values.horizontalPodAutoscaler.cpuUtilization }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.horizontalPodAutoscaler.cpuUtilization }}
+  {{- end }}
+  {{- if .Values.horizontalPodAutoscaler.memUtilization }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.horizontalPodAutoscaler.memUtilization }}
+  {{- end }}
+{{- end -}}

--- a/helm/stac-fastapi-eodag/templates/ingress.yaml
+++ b/helm/stac-fastapi-eodag/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -35,9 +35,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" .Values.ingress.servicePort "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -45,9 +43,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" .Values.ingress.servicePort "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}

--- a/helm/stac-fastapi-eodag/values.yaml
+++ b/helm/stac-fastapi-eodag/values.yaml
@@ -288,6 +288,19 @@ resources:
   limits: {}
   requests: {}
 
+## STAC FastAPI EODAG horizontal autoscaling
+## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+## @param horizontalPodAutoscaler.enabled Decide to enable or disable the horizontal pod autoscaler
+## @param horizontalPodAutoscaler.maxReplicas The maximum number of replicas that are allowed to run simultaneously
+## @param horizontalPodAutoscaler.cpuUtilization The maximum CPU utilization target computed in % of the CPU resources request.
+## @param horizontalPodAutoscaler.memUtilization The maximum RAM utilization target computed in % of the RAM resources request.
+##
+horizontalPodAutoscaler:
+  enabled: false
+  maxReplicas: 10
+  cpuUtilization: 50
+  memUtilization: 50
+
 ## Configure Pods Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled stac-fastapi-eodag pods' Security Context
@@ -426,6 +439,11 @@ priorityClassName: ""
 ##
 runtimeClassName: ""
 
+## @param terminationGracePeriodSeconds Termination grace period in seconds for pods
+## This allows pods to gracefully shut down before being forcefully terminated
+##
+terminationGracePeriodSeconds: 30
+
 ## @param lifecycleHooks for the stac-fastapi-eodag container(s) to automate configuration before or after startup
 ##
 lifecycleHooks: {}
@@ -476,6 +494,11 @@ sidecars: []
 ##    command: ['sh', '-c', 'echo "hello world"']
 ##
 initContainers: []
+
+## Deployment configuration
+deployment:
+  ## @param deployment.annotations Additional custom annotations for stac-fastapi-eodag deployment
+  annotations: {}
 
 ## Service configuration
 ##

--- a/helm/stac-fastapi-eodag/values.yaml
+++ b/helm/stac-fastapi-eodag/values.yaml
@@ -663,7 +663,7 @@ serviceAccount:
   annotations: {}
   ## @param serviceAccount.automountServiceAccountToken Automount service account token for the server service account
   ##
-  automountServiceAccountToken: false
+  automountServiceAccountToken: true
 
 
 ## @section Telemetry parameters


### PR DESCRIPTION
This PR enhances the `stac-fastapi-eodag` Helm chart with improved deployment configuration options and comprehensive deployment documentation.

# 🔧 Configuration Improvements
- Added configurable `terminationGracePeriodSeconds`: Allows customization of pod termination grace period through Helm values
- Added `HorizontalPodAutoscaler`

# 📚 Documentation
- Added [DEPLOYMENT.md](https://github.com/CS-SI/stac-fastapi-eodag/blob/fix/deployment/helm/stac-fastapi-eodag/DEPLOYMENT.md): Comprehensive deployment guide covering:
- Automatic configuration reloading with Reloader
- Graceful shutdown configuration for long-running operations

