### PR TITLE
test: add `{posargs}` to `pytest` invocation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
 		--cov-report=xml:test-reports/coverage.xml \
 		--junitxml=test-reports/junit-report.xml \
 		--html=test-reports/tests/report.html \
-        --self-contained-html
+        --self-contained-html {posargs}
 
 [testenv:pypi]
 skip_install = true


### PR DESCRIPTION
Adding `{posargs}` to `pytest` invocation let's launching selected tests with tox, e.g.:

```
tox -e 313 -- tests/test_download.py::test_download_item_from_collection_stream
```