### PR TITLE
feat: ORDERABLE self links now work properly

### DIFF
--- a/stac_fastapi/eodag/core.py
+++ b/stac_fastapi/eodag/core.py
@@ -522,19 +522,19 @@ class EodagCoreClient(CustomCoreClient):
 
         # Handle query params set up for _ORDERABLE_ items
         if "_ORDERABLE_" in item_id:
-            bbox: Optional[list[NumType]] = request.query_params.getlist("bbox")
-            datetime: Optional[str] = request.query_params.getlist("datetime")
-            query: Optional[dict[str, Any]] = request.query_params.getlist("query")
-            intersects: Optional[str] = request.query_params.getlist("intersects")
-            filter_expr: Optional[str] = request.query_params.getlist("filter_expr")
-            filter_lang: Optional[str] = request.query_params.getlist("filter_lang")
+            _bbox = request.query_params.getlist("bbox")
+            _datetime = request.query_params.getlist("datetime")
+            _query = request.query_params.getlist("query")
+            _intersects = request.query_params.getlist("intersects")
+            _filter_expr = request.query_params.getlist("filter_expr")
+            _filter_lang = request.query_params.getlist("filter_lang")
 
-            bbox = bbox[0] if bbox else bbox
-            datetime = datetime[0] if datetime else datetime
-            query = ast.literal_eval(query[0]) if query else query
-            intersects = intersects[0] if intersects else intersects
-            filter_expr = ast.literal_eval(filter_expr[0]) if filter_expr else filter_expr
-            filter_lang = filter_lang[0] if filter_lang else "cql2-text"
+            bbox = _bbox[0] if _bbox else None
+            datetime = _datetime[0] if _datetime else None
+            query = ast.literal_eval(_query[0]) if _query else None
+            intersects = _intersects[0] if _intersects else None
+            filter_expr = ast.literal_eval(_filter_expr[0]) if _filter_expr else None
+            filter_lang = _filter_lang[0] if _filter_lang else "cql2-text"
 
             base_args = {
                 "collections": [collection_id],

--- a/stac_fastapi/eodag/models/links.py
+++ b/stac_fastapi/eodag/models/links.py
@@ -332,10 +332,26 @@ class ItemLinks(CollectionLinksBase):
 
     def link_self(self) -> dict[str, str]:
         """Create the self link."""
+
+        _href = self.resolve(f"collections/{self.collection_id}/items/{self.item_id}")
+
+        # Orderable items need to contain their search parameters on the self link
+        # to be able to return them later on.
+        if "_ORDERABLE_" in self.item_id:
+            _params = ""
+            # POST search
+            if hasattr(self.request, "_json"):
+                _params = urlencode(self.request._json)
+            else:
+                # GET search
+                _params = str(self.request.query_params)
+
+            _href = f"{_href}?{_params}"
+
         return {
             "rel": Relations.self.value,
             "type": MimeTypes.geojson.value,
-            "href": self.resolve(f"collections/{self.collection_id}/items/{self.item_id}"),
+            "href": _href,
             "title": "Original item link",
         }
 


### PR DESCRIPTION
Orderables dont technically exists until they are orderered.
Due to this, the way `self` link normally works (using `/collections/<col>/items/<item_id>` endpoint) does not include the search parameters that actually instansiate the orderable.

This pull request adds the search parameters to the self links and allows `/collections/<col>/items/<item_id>` endpoint to parse them to provide the right feature.

Fixes https://github.com/CS-SI/stac-fastapi-eodag/issues/59