### PR TITLE
feat: add geometry and bbox converters

### DIFF
--- a/stac_fastapi/eodag/extensions/collection_order.py
+++ b/stac_fastapi/eodag/extensions/collection_order.py
@@ -42,6 +42,7 @@ from stac_fastapi.eodag.models.stac_metadata import (
     CommonStacMetadata,
     create_stac_item,
 )
+from stac_fastapi.eodag.utils import convert_from_geojson_polytope
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,11 @@ class BaseCollectionOrderClient:
             request_params = request_body.model_dump(exclude={"federation_backends": True})
             # use eodag formatting for search
             search_params = {f"ecmwf:{k}": v for k, v in request_params.items()}
+            # ECMWF Polytope uses non-geojson structure for features
+            if "ecmwf:feature" in search_params:
+                if search_params["ecmwf:feature"]["type"] == "polygon":
+                    search_params["geometry"] = convert_from_geojson_polytope(search_params["ecmwf:feature"])
+                    search_params.pop("ecmwf:feature")
 
         settings = get_settings()
         validate: bool = settings.validate_request

--- a/stac_fastapi/eodag/extensions/collection_order.py
+++ b/stac_fastapi/eodag/extensions/collection_order.py
@@ -42,7 +42,7 @@ from stac_fastapi.eodag.models.stac_metadata import (
     CommonStacMetadata,
     create_stac_item,
 )
-from stac_fastapi.eodag.utils import convert_from_geojson_polytope
+from stac_fastapi.eodag.utils import convert_from_area_to_bbox, convert_from_geojson_polytope
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +96,10 @@ class BaseCollectionOrderClient:
                 if search_params["ecmwf:feature"]["type"] == "polygon":
                     search_params["geometry"] = convert_from_geojson_polytope(search_params["ecmwf:feature"])
                     search_params.pop("ecmwf:feature")
+            # convert bounding box format
+            if "ecmwf:area" in search_params:
+                search_params["bbox"] = convert_from_area_to_bbox(search_params["ecmwf:area"])
+                search_params.pop("ecmwf:area")
 
         settings = get_settings()
         validate: bool = settings.validate_request

--- a/stac_fastapi/eodag/utils.py
+++ b/stac_fastapi/eodag/utils.py
@@ -151,3 +151,17 @@ def convert_from_geojson_polytope(geom: dict[str, Any]) -> Polygon:
         return Polygon(polygon_args)
     else:
         raise ValidationError("convert_from_geojson_polytope only accepts shapes of type polygon")
+
+
+def convert_from_area_to_bbox(area: list[float]) -> list[float]:
+    """
+    Converts the bounding box from area format to bbox format.
+
+    bbox format: [min_lon,min_lat,max_lon,max_lat]
+    area format: [max_lat,min_lon,min_lat,max_lon]
+
+    :param area: bounding box in area format.
+    :returns: bounding box in bbox format.
+    """
+    max_lat, min_lon, min_lat, max_lon = area
+    return [min_lon, min_lat, max_lon, max_lat]

--- a/stac_fastapi/eodag/utils.py
+++ b/stac_fastapi/eodag/utils.py
@@ -26,6 +26,8 @@ from urllib.parse import unquote_plus
 import orjson
 from shapely.geometry import Point, Polygon
 
+from eodag.utils.exceptions import ValidationError
+
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
 
@@ -134,3 +136,18 @@ def check_poly_is_point(poly: Polygon) -> Union[Point, Polygon]:
         return Point(poly.exterior.coords[0])
     else:
         return poly
+
+
+def convert_from_geojson_polytope(geom: dict[str, Any]) -> Polygon:
+    """
+    Converts from ECMWF Polytope non-geojson shape to Shapely polygon
+
+    :param geom: ECMWF Polytope shape.
+    :returns: A Shapely polygon.
+    """
+    if geom["type"] == "polygon":
+        shape: list = geom["shape"]
+        polygon_args = [(p[1], p[0]) for p in shape]
+        return Polygon(polygon_args)
+    else:
+        raise ValidationError("convert_from_geojson_polytope only accepts shapes of type polygon")


### PR DESCRIPTION
This PR converts some geometry data structures in a format handled by EODAG:

- ECMWF Polytope uses non-geojson structure for features. Converts it to a Shapely polygon.
- Converts the bounding box from area format (`[max_lat,min_lon,min_lat,max_lon]`) to bbox format (`[min_lon,min_lat,max_lon,max_lat]`).