### PR TITLE
fix: remove numberMatched when count is False

### DIFF
--- a/stac_fastapi/eodag/core.py
+++ b/stac_fastapi/eodag/core.py
@@ -216,8 +216,12 @@ class EodagCoreClient(CustomCoreClient):
         feature_collection = ItemCollection(
             type="FeatureCollection",
             features=features,
+            numberMatched=search_result.number_matched,
             numberReturned=len(features),
         )
+        # Remove numberMatched if it is None
+        if feature_collection.get("numberMatched") is None:
+            feature_collection.pop("numberMatched")
 
         # pagination
         if "provider" not in request.state.eodag_args and len(search_result) > 0:

--- a/stac_fastapi/eodag/core.py
+++ b/stac_fastapi/eodag/core.py
@@ -216,7 +216,6 @@ class EodagCoreClient(CustomCoreClient):
         feature_collection = ItemCollection(
             type="FeatureCollection",
             features=features,
-            numberMatched=search_result.number_matched,
             numberReturned=len(features),
         )
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -104,7 +104,7 @@ async def test_count_search(request_valid, defaults, mock_search, mock_search_re
             validate=True,
         ),
     )
-    assert response["numberMatched"] is None
+    assert response.get("numberMatched") is None
 
     # Reset search mock, set "number_matched" attribute of the search results mock for a counting search
     # and set count to True

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -533,7 +533,6 @@ async def test_ids_post_search(request_valid, defaults):
 async def test_search_response_contains_pagination_info(request_valid, defaults):
     """Responses to valid search requests must return a geojson with pagination info in properties"""
     response = await request_valid(f"search?collections={defaults.collection}")
-    assert "numberMatched" in response
     assert "numberReturned" in response
 
 


### PR DESCRIPTION
remove unused numberMatched  because it is always null