### PR TITLE
refactor: remove peps provider

### DIFF
--- a/helm/stac-fastapi-eodag/values.yaml
+++ b/helm/stac-fastapi-eodag/values.yaml
@@ -137,6 +137,13 @@ providers: ""
 ## doc: https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html
 ## ref: https://github.com/CS-SI/eodag/blob/master/eodag/resources/user_conf_template.yml
 config:
+  # cop_cds:
+  #     priority: # Lower value means lower priority (Default: 0)
+  #     api:
+  #         outputs_prefix:
+  #         credentials:
+  #             username:
+  #             password:
   # cop_dataspace:
   #     priority: # Lower value means lower priority (Default: 0)
   #     search:   # Search parameters configuration

--- a/helm/stac-fastapi-eodag/values.yaml
+++ b/helm/stac-fastapi-eodag/values.yaml
@@ -137,7 +137,7 @@ providers: ""
 ## doc: https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html
 ## ref: https://github.com/CS-SI/eodag/blob/master/eodag/resources/user_conf_template.yml
 config:
-  # peps:
+  # cop_dataspace:
   #   priority: # Lower value means lower priority (Default: 1)
   #   search:  # Search parameters configuration
   #   download:

--- a/helm/stac-fastapi-eodag/values.yaml
+++ b/helm/stac-fastapi-eodag/values.yaml
@@ -138,25 +138,6 @@ providers: ""
 ## ref: https://github.com/CS-SI/eodag/blob/master/eodag/resources/user_conf_template.yml
 config:
   # cop_dataspace:
-  #   priority: # Lower value means lower priority (Default: 1)
-  #   search:  # Search parameters configuration
-  #   download:
-  #       extract:  # whether to extract the downloaded products, only applies to archived products (true or false, Default: true).
-  #       outputs_prefix: # where to store downloaded products, as an absolute file path (Default: local temporary directory)
-  #       dl_url_params:  # additional parameters to pass over to the download url as an url parameter
-  #       delete_archive: # whether to delete the downloaded archives (true or false, Default: true).
-  #   auth:
-  #       credentials:
-  #           username:
-  #           password:
-  # cop_cds:
-  #     priority: # Lower value means lower priority (Default: 0)
-  #     api:
-  #         outputs_prefix:
-  #         credentials:
-  #             username:
-  #             password:
-  # cop_dataspace:
   #     priority: # Lower value means lower priority (Default: 0)
   #     search:   # Search parameters configuration
   #     download:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,11 +113,11 @@ def app() -> Iterator[FastAPI]:
     """
     providers_dict = ProvidersDict(
         {
-            "peps": Provider(
+            "cop_dataspace": Provider(
                 ProviderConfig.from_mapping(
                     {
-                        "name": "peps",
-                        "url": "https://peps.cnes.fr",
+                        "name": "cop_dataspace",
+                        "url": "https://dataspace.copernicus.eu",
                         "search": {"type": "QueryStringSearch"},
                         "products": {"S2_MSI_L1C": {"_collection": "SENTINEL-2"}},
                     }
@@ -177,9 +177,9 @@ def mock_search_result():
                         "keywords": [],
                         "product:type": "OCN",
                         "eodag:download_link": (
-                            "https://peps.cnes.fr/resto/collections/S1/578f1768-e66e-5b86-9363-b19f8931cc7b/download"
+                            "https://dataspace.copernicus.eu/resto/collections/S1/578f1768-e66e-5b86-9363-b19f8931cc7b/download"
                         ),
-                        "eodag:provider": "peps",
+                        "eodag:provider": "cop_dataspace",
                         "collection": "S1_SAR_OCN",
                         "platform": "S1A",
                         "eo:cloud_cover": 0,
@@ -208,7 +208,7 @@ def mock_search_result():
                         "sar:instrument_mode": None,
                         "quicklook": None,
                         "order:status": ONLINE_STATUS,
-                        "peps:providerProperty": "foo",
+                        "cop_dataspace:providerProperty": "foo",
                     },
                     "id": "578f1768-e66e-5b86-9363-b19f8931cc7b",
                     "type": "Feature",
@@ -224,7 +224,7 @@ def mock_search_result():
                         ],
                         "type": "Polygon",
                     },
-                    "assets": {"asset1": {"title": "asset1", "href": "https://peps.cnes.fr"}},
+                    "assets": {"asset1": {"title": "asset1", "href": "https://dataspace.copernicus.eu"}},
                 },
                 {
                     "properties": {
@@ -234,9 +234,9 @@ def mock_search_result():
                         "keywords": [],
                         "product:type": "OCN",
                         "eodag:download_link": (
-                            "https://peps.cnes.fr/resto/collections/S1/578f1768-e66e-5b86-9363-b19f8931cc7c/download"
+                            "https://dataspace.copernicus.eu/resto/collections/S1/578f1768-e66e-5b86-9363-b19f8931cc7c/download"
                         ),
-                        "eodag:provider": "peps",
+                        "eodag:provider": "cop_dataspace",
                         "collection": "S1_SAR_OCN",
                         "platform": "S1A",
                         "eo:cloud_cover": 0,
@@ -288,8 +288,8 @@ def mock_search_result():
     config = PluginConfig()
     config.priority = 0
     for p in search_result:
-        p.downloader = Download("peps", config)
-        p.downloader_auth = Authentication("peps", config)
+        p.downloader = Download("cop_dataspace", config)
+        p.downloader_auth = Authentication("cop_dataspace", config)
     search_result.number_matched = None
     return search_result
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,7 +234,7 @@ def mock_search_result():
                         "keywords": [],
                         "product:type": "OCN",
                         "eodag:download_link": (
-                            "https://dataspace.copernicus.eu/resto/collections/S1/578f1768-e66e-5b86-9363-b19f8931cc7c/download"
+                            "https://catalogue.dataspace.copernicus.eu/odata/v1/Products(578f1768-e66e-5b86-9363-b19f8931cc7c)/$value"
                         ),
                         "eodag:provider": "cop_dataspace",
                         "collection": "S1_SAR_OCN",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,7 +224,7 @@ def mock_search_result():
                         ],
                         "type": "Polygon",
                     },
-                    "assets": {"asset1": {"title": "asset1", "href": "https://dataspace.copernicus.eu"}},
+                    "assets": {"asset1": {"title": "asset1", "href": "https://catalogue.dataspace.copernicus.eu"}},
                 },
                 {
                     "properties": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,7 +177,7 @@ def mock_search_result():
                         "keywords": [],
                         "product:type": "OCN",
                         "eodag:download_link": (
-                            "https://dataspace.copernicus.eu/resto/collections/S1/578f1768-e66e-5b86-9363-b19f8931cc7b/download"
+                            "https://catalogue.dataspace.copernicus.eu/odata/v1/Products(578f1768-e66e-5b86-9363-b19f8931cc7b)/$value"
                         ),
                         "eodag:provider": "cop_dataspace",
                         "collection": "S1_SAR_OCN",

--- a/tests/resources/wrong_credentials_conf.yml
+++ b/tests/resources/wrong_credentials_conf.yml
@@ -98,11 +98,6 @@ meteoblue:
     auth:
         credentials:
             apikey: wrong_apikey
-peps:
-    auth:
-        credentials:
-            password: wrong_password
-            username: wrong_username
 planetary_computer:
     auth:
         credentials:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -23,10 +23,10 @@ from unittest.mock import ANY
 async def test_landing_page(request_valid):
     """Test the root route."""
     response = await request_valid("/")
-    assert response["federation"]["peps"] == {
-        "title": "peps",
+    assert response["federation"]["cop_dataspace"] == {
+        "title": "cop_dataspace",
         "description": ANY,
-        "url": "https://peps.cnes.fr",
+        "url": "https://dataspace.copernicus.eu",
     }
     assert len(response["federation"]) > 1
     assert "https://api.openeo.org/extensions/federation/0.1.0" in response["stac_extensions"]

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -99,9 +99,9 @@ async def test_search_collections_query(app_client, mock_list_collections):
     collection1 = Collection(id="S2_MSI_L1C", title="SENTINEL2 Level-1C")
     collection2 = Collection(id="S2_MSI_L2A")
     mock_list_collections.return_value = CollectionsList([collection1, collection2])
-    r = await app_client.get('/collections?query={"federation:backends":{"eq":"peps"}}')
+    r = await app_client.get('/collections?query={"federation:backends":{"eq":"cop_dataspace"}}')
 
-    mock_list_collections.assert_called_once_with(provider="peps", fetch_providers=False)
+    mock_list_collections.assert_called_once_with(provider="cop_dataspace", fetch_providers=False)
     assert r.status_code == 200
     assert ["S2_MSI_L1C", "S2_MSI_L2A"] == [col["id"] for col in r.json().get("collections", [])]
 

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -122,7 +122,7 @@ def fixture_mock_fetch_external_stac_collections(mocker: MockerFixture) -> Magic
         "test-product": {
             "id": "test-product",
             "title": "Mocked Title",
-            "description": "Mocked Description",
+            "description": "Not Available",
             "license": "Mocked License",
             "summaries": {
                 "platform": ["Mocked Platform"],
@@ -191,7 +191,7 @@ def fixture_mock_dag() -> MagicMock:
             {
                 "id": "test-product",
                 "title": "Mocked Title",
-                "description": "Mocked Description",
+                "description": "Not Available",
                 "keywords": ["keyword1", "keyword2"],
                 "instruments": ["Mocked Instrument"],
                 "platform": "Mocked Platform",
@@ -226,7 +226,7 @@ def fixture_mock_dag() -> MagicMock:
             {
                 "id": "test-product",
                 "title": "Existing Title",
-                "description": "Mocked Description",
+                "description": "Not Available",
                 "keywords": ["keyword1", "keyword2"],
                 "instruments": ["Existing Instrument"],
                 "platform": "Mocked Platform",

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -35,7 +35,7 @@ async def test_download_item_from_collection_stream(
     """Download through eodag server catalog should return a valid response"""
     mock_base_stream_download.return_value = stream_response
 
-    resp = await request_valid_raw(f"data/peps/{defaults.collection}/foo/downloadLink")
+    resp = await request_valid_raw(f"data/cop_dataspace/{defaults.collection}/foo/downloadLink")
     assert resp.content == b"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     assert resp.headers["content-disposition"] == 'attachment; filename="alphabet.txt"'
     assert resp.headers["content-type"] == "text/plain"
@@ -51,7 +51,7 @@ async def test_download_item_from_collection_no_stream(
     mock_download.return_value = expected_file
     mock_base_stream_download.side_effect = NotImplementedError()
 
-    await request_valid_raw(f"data/peps/{defaults.collection}/foo/downloadLink")
+    await request_valid_raw(f"data/cop_dataspace/{defaults.collection}/foo/downloadLink")
     mock_download.assert_called_once()
     # downloaded file should have been immediatly deleted from the server
     assert not os.path.exists(expected_file), f"File {expected_file} should have been deleted"
@@ -69,12 +69,12 @@ async def test_download_auto_order_whitelist(
     """Test that the order method is called when downloading a product
     from a federation backend included in the auto_order_whitelist.
 
-    This test simulates downloading a product from a federated backend ('peps')
+    This test simulates downloading a product from a federated backend ('cop_dataspace')
     and checks that the order function is triggered when the backend is present
     in the auto_order_whitelist configuration.
     """
-    federation_backend = "peps"
-    # update the auto_order_whitelist setting to include "peps"
+    federation_backend = "cop_dataspace"
+    # update the auto_order_whitelist setting to include "cop_dataspace"
     auto_order_whitelist = get_settings().auto_order_whitelist
     get_settings().auto_order_whitelist = [federation_backend]
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -30,7 +30,7 @@ async def test_search_no_results_with_errors(app, app_client, mocker):
     errors = [
         ("usgs", Exception("Generic exception", "Details of the error")),
         ("theia", TimeOutError("Timeout message")),
-        ("peps", req_err),
+        ("cop_dataspace", req_err),
         ("creodias", AuthenticationError("Authentication message")),
         (
             "creodias_s3",
@@ -58,7 +58,7 @@ async def test_search_no_results_with_errors(app, app_client, mocker):
                 "status_code": 504,
             },
             {
-                "provider": "peps",
+                "provider": "cop_dataspace",
                 "error": "RequestError",
                 "message": "Request error message with status code",
                 "status_code": 400,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -508,7 +508,7 @@ async def test_search_response_contains_pagination_info(request_valid, defaults)
     [
         (None, None, [False, False, False, False]),
         (True, None, [True, True, True, True]),
-        (True, "https://dataspace.copernicus.eu", [False, False, True, False]),
+        (True, "https://catalogue.dataspace.copernicus.eu", [False, False, True, False]),
     ],
     ids=[
         "no alt links by default",
@@ -528,7 +528,7 @@ async def test_assets_alt_url_blacklist(
     """Search through eodag server must not have alternate link if in blacklist"""
 
     search_result = mock_search_result
-    search_result[0].assets.update({"asset1": {"href": "https://dataspace.copernicus.eu"}})
+    search_result[0].assets.update({"asset1": {"href": "https://catalogue.dataspace.copernicus.eu"}})
     search_result[1].assets.update({"asset1": {"href": "https://somewhere.fr"}})
     # make assets of the second product available for this test
     search_result[1].properties["order:status"] = ONLINE_STATUS

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -122,7 +122,7 @@ async def test_items_response(request_valid, defaults):
         "geometry",
         "properties",
     }
-    assert first_props["federation:backends"] == ["peps"]
+    assert first_props["federation:backends"] == ["cop_dataspace"]
     assert first_props["datetime"] == "2018-02-15T23:53:22.871Z"
     assert first_props["start_datetime"] == "2018-02-15T23:53:22.871Z"
     assert first_props["end_datetime"] == "2018-02-16T00:12:14.035Z"
@@ -136,14 +136,14 @@ async def test_items_response(request_valid, defaults):
     assert "asset1" in res[0]["assets"]
     assert (
         res[0]["assets"]["asset1"]["href"]
-        == f"http://testserver/data/peps/{res[0]['collection']}/{res[0]['id']}/asset1"
+        == f"http://testserver/data/cop_dataspace/{res[0]['collection']}/{res[0]['id']}/asset1"
     )
     assert res[1]["properties"]["order:status"] == "orderable"
     assert "assets" in res[0]
     assert "asset1" in res[0]["assets"]
     assert (
         res[0]["assets"]["asset1"]["href"]
-        == f"http://testserver/data/peps/{res[0]['collection']}/{res[0]['id']}/asset1"
+        == f"http://testserver/data/cop_dataspace/{res[0]['collection']}/{res[0]['id']}/asset1"
     )
     expected_extensions = [
         "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
@@ -155,9 +155,9 @@ async def test_items_response(request_valid, defaults):
     for ext in expected_extensions:
         assert ext in res[0]["stac_extensions"]
 
-    # check order status and storage tier properties of the "OFFLINE" item when peps is whitelisted
+    # check order status and storage tier properties of the "OFFLINE" item when cop_dataspace is whitelisted
     auto_order_whitelist = get_settings().auto_order_whitelist
-    get_settings().auto_order_whitelist = ["peps"]
+    get_settings().auto_order_whitelist = ["cop_dataspace"]
 
     resp_json = await request_valid(
         f"search?collections={defaults.collection}",
@@ -197,7 +197,7 @@ async def test_assets_with_different_download_base_url(request_valid, defaults):
     assert "asset1" in res[0]["assets"]
     assert (
         res[0]["assets"]["asset1"]["href"]
-        == f"http://otherserver/data/peps/{res[0]['collection']}/{res[0]['id']}/asset1"
+        == f"http://otherserver/data/cop_dataspace/{res[0]['collection']}/{res[0]['id']}/asset1"
     )
 
 
@@ -508,7 +508,7 @@ async def test_search_response_contains_pagination_info(request_valid, defaults)
     [
         (None, None, [False, False, False, False]),
         (True, None, [True, True, True, True]),
-        (True, "https://peps.cnes.fr", [False, False, True, False]),
+        (True, "https://dataspace.copernicus.eu", [False, False, True, False]),
     ],
     ids=[
         "no alt links by default",
@@ -528,7 +528,7 @@ async def test_assets_alt_url_blacklist(
     """Search through eodag server must not have alternate link if in blacklist"""
 
     search_result = mock_search_result
-    search_result[0].assets.update({"asset1": {"href": "https://peps.cnes.fr"}})
+    search_result[0].assets.update({"asset1": {"href": "https://dataspace.copernicus.eu"}})
     search_result[1].assets.update({"asset1": {"href": "https://somewhere.fr"}})
     # make assets of the second product available for this test
     search_result[1].properties["order:status"] = ONLINE_STATUS
@@ -552,17 +552,17 @@ async def test_assets_alt_url_blacklist(
         (
             "POST",
             "search",
-            {"collections": ["{defaults.collection}"], "query": {"federation:backends": {"eq": "peps"}}},
-            {"provider": "peps"},
+            {"collections": ["{defaults.collection}"], "query": {"federation:backends": {"eq": "cop_dataspace"}}},
+            {"provider": "cop_dataspace"},
         ),
         # POST with no provider specified
         ("POST", "search", {"collections": ["{defaults.collection}"]}, {}),
         # GET with provider specified
         (
             "GET",
-            'search?collections={defaults.collection}&query={{"federation:backends":{{"eq":"peps"}} }}',
+            'search?collections={defaults.collection}&query={{"federation:backends":{{"eq":"cop_dataspace"}} }}',
             None,
-            {"provider": "peps"},
+            {"provider": "cop_dataspace"},
         ),
         # GET with no provider specified
         ("GET", "search?collections={defaults.collection}", None, {}),
@@ -684,7 +684,7 @@ async def test_pagination_basic(request_valid, defaults, method, has_next_token,
     # Create search result based on whether next token should be present
     if has_next_token:
         search_result = SearchResult(
-            [EOProduct("peps", {"id": "_", "collection": "_"})] * 10, next_page_token=next_token
+            [EOProduct("cop_dataspace", {"id": "_", "collection": "_"})] * 10, next_page_token=next_token
         )
     else:
         search_result = SearchResult([])
@@ -740,7 +740,9 @@ async def test_pagination_with_token(request_valid, defaults, method):
     next_token = "next_token_456"
 
     # Create a mock search result for the next page
-    search_result = SearchResult([EOProduct("peps", {"id": "_", "collection": "_"})] * 10, next_page_token=next_token)
+    search_result = SearchResult(
+        [EOProduct("cop_dataspace", {"id": "_", "collection": "_"})] * 10, next_page_token=next_token
+    )
 
     # Set up request parameters based on method
     if method == "GET":


### PR DESCRIPTION
Removes peps provider as its end-of-service is planned on 2026-03-25.

All providers now have the same priority level (0). peps is replaced with cop_dataspace in documentation examples and tests.

See https://geodes.cnes.fr/peps-clap-de-fin-pour-la-plateforme-francaise-dacces-aux-donnees-sentinel-peps/