### PR TITLE
refactor: quotas errors and query extension syntax handling

### DIFF
--- a/stac_fastapi/eodag/core.py
+++ b/stac_fastapi/eodag/core.py
@@ -33,6 +33,7 @@ from pydantic_core import InitErrorDetails, PydanticCustomError
 from pygeofilter.backends.cql2_json import to_cql2
 from pygeofilter.parsers.cql2_json import parse as parse_json
 from pygeofilter.parsers.cql2_text import parse as parse_cql2_text
+from stac_fastapi.api.models import create_post_request_model
 from stac_fastapi.types.errors import NotFoundError
 from stac_fastapi.types.requests import get_base_url
 from stac_fastapi.types.rfc3339 import str_to_interval
@@ -448,6 +449,10 @@ class EodagCoreClient(CustomCoreClient):
         :param kwargs: Additional keyword arguments.
         :returns: Found items.
         """
+        search_post_model = create_post_request_model(self.extensions)
+        request_json = await request.json()
+        search_post_model.model_validate(request_json, extra="forbid")
+
         return await self._search_base(search_request, request)
 
     async def get_search(

--- a/stac_fastapi/eodag/errors.py
+++ b/stac_fastapi/eodag/errors.py
@@ -35,6 +35,7 @@ from eodag.utils.exceptions import (
     MisconfiguredError,
     NoMatchingCollection,
     NotAvailableError,
+    QuotaExceededError,
     RequestError,
     TimeOutError,
     UnsupportedCollection,
@@ -60,6 +61,7 @@ EODAG_DEFAULT_STATUS_CODES: dict[type, int] = {
     UnsupportedProvider: status.HTTP_404_NOT_FOUND,
     ValidationError: status.HTTP_400_BAD_REQUEST,
     RequestError: status.HTTP_400_BAD_REQUEST,
+    QuotaExceededError: status.HTTP_429_TOO_MANY_REQUESTS,
 }
 
 logger = logging.getLogger(__name__)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -38,6 +38,33 @@ async def test_request_params_invalid(bbox, request_not_valid, defaults):
     await request_not_valid(f"search?collections={defaults.collection}&bbox={bbox}")
 
 
+async def test_invalid_post_search_request(request_not_valid):
+    """
+    Test if an invalid POST /search request body returns an error
+    """
+    post_body = {
+        "collections": ["S2_MSI_L1C"],
+        "limit": 1,
+        "sortby": [{"field": "datetime", "direction": "asc"}],
+        "query": {"federation:backends": {"eq": "creodias_s3"}},
+        "ecmwf:year": {"eq": "2000"},  # additional parameter outside of query
+    }
+    await request_not_valid("search", "POST", post_body)
+
+
+async def test_valid_post_search_request(request_valid):
+    """
+    Test if a valid POST /search request body passes validation
+    """
+    post_body = {
+        "collections": ["S2_MSI_L1C"],
+        "limit": 1,
+        "sortby": [{"field": "datetime", "direction": "asc"}],
+        "query": {"federation:backends": {"eq": "creodias_s3"}},
+    }
+    await request_valid(url="search", method="POST", post_data=post_body)
+
+
 @pytest.mark.parametrize("input_bbox,expected_geom", [(None, None), ("bbox_csv", "bbox_list")])
 async def test_request_params_valid(request_valid, defaults, input_bbox, expected_geom):
     """


### PR DESCRIPTION
- handle `QuotaExceededError` raised by eodag (follows https://github.com/CS-SI/eodag/pull/2139)
- do not allow POST search request parameters with additional parameters outside of query extension