### PR TITLE
ci: upgrade GitHub Actions versions and add SonarQube job

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -9,7 +9,7 @@ jobs:
     name: No git-sourced dependencies on main
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Ensure eodag is not installed from a git source
         run: |
           if grep -E 'eodag\s*(\[.*\])?\s*@\s*git\+' pyproject.toml; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Get history and tags for SCM versioning to work
           fetch-depth: 0
       - name: Install the latest version of uv with cache enabled
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Determine the container tag and labels
         id: container_tag
@@ -47,10 +47,10 @@ jobs:
           echo "CONTAINER_TAG=$CONTAINER_TAG" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Extract container metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -75,7 +75,7 @@ jobs:
 
       - name: Build and push container image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    - cron: "0 7 * * 1"
   workflow_dispatch:
 
 jobs:
@@ -15,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # Get history and tags for SCM versioning to work
         fetch-depth: 0
     - name: Install the latest version of uv with cache enabled
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         version: "latest"
         enable-cache: true
@@ -33,16 +31,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.9, "3.14"]
+        python-version: [3.9, 3.14]
         os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # Get history and tags for SCM versioning to work
         fetch-depth: 0
     - name: Install the latest version of uv with cache enabled
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         version: "latest"
         enable-cache: true
@@ -51,7 +49,7 @@ jobs:
       run: uvx --python ${{ matrix.python-version }} --with tox-uv --with tox-gh-actions tox
     - name: Upload Unit Test Results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: unit-test-results-python${{ matrix.python-version }}-${{ matrix.os }}
         path: |
@@ -66,7 +64,7 @@ jobs:
 
     steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: artifacts
 
@@ -77,7 +75,7 @@ jobs:
         files: artifacts/*/junit-report.xml
 
     - name: Produce the coverage report for Ubuntu
-      uses: insightsengineering/coverage-action@v2
+      uses: insightsengineering/coverage-action@v3
       with:
         # Path to the Cobertura XML report.
         path: artifacts/unit-test-results-python3.14-ubuntu-latest/coverage.xml
@@ -111,15 +109,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # Get history and tags for SCM versioning to work
         fetch-depth: 0
     - name: Install the latest version of uv with cache enabled
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         version: "latest"
         enable-cache: true
         cache-dependency-glob: ""
     - name: Testing with tox and sphinx (to have rst2html.py utility available)
       run: uvx --with tox-uv --with sphinx tox -e pypi
+
+  sonarqube:
+    name: SonarQube scan
+    needs: tests
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    steps:
+    - name: Checkout the repo
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Download Ubuntu coverage artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: unit-test-results-python3.14-ubuntu-latest
+        path: test-reports
+    - name: SonarQube Scan
+      uses: SonarSource/sonarqube-scan-action@v7
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      with:
+        args: >
+          -Dsonar.projectKey=cs-si_stac-fastapi-eodag
+          -Dsonar.organization=cs-si
+          -Dsonar.python.version=3.14
+          -Dsonar.python.coverage.reportPaths=test-reports/coverage.xml
+          -Dsonar.sources=stac_fastapi/
+          -Dsonar.tests=tests/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
   <img src="https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png" alt="FastAPI" height=100 />
 </p>
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=cs-si_stac-fastapi-eodag&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=cs-si_stac-fastapi-eodag)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/CS-SI/stac-fastapi-eodag)
+
 [EODAG](https://github.com/CS-SI/eodag) backend for [stac-fastapi](https://github.com/stac-utils/stac-fastapi), the [FastAPI](https://fastapi.tiangolo.com/) implementation of the [STAC API spec](https://github.com/radiantearth/stac-api-spec)
 
 stac-fastapi-eodag combines the capabilities of EODAG and STAC FastAPI to provide a powerful, unified API for accessing Earth observation data from various providers.


### PR DESCRIPTION
## ci: upgrade GitHub Actions versions and add SonarQube scan

### Summary

Brings all GitHub Actions dependencies up to their latest major versions and adds a SonarQube scan job to the test workflow.

### Changes

#### Action version upgrades (all workflows)

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` / `v5` | `v6` |
| `astral-sh/setup-uv` | `v3` | `v8.1.0` (exact — floating major tags removed since v8.0.0) |
| `actions/upload-artifact` | `v4` | `v7` |
| `actions/download-artifact` | `v4` | `v8` |
| `insightsengineering/coverage-action` | `v2` | `v3` |
| `docker/setup-buildx-action` | `v3` | `v4` |
| `docker/login-action` | `v3` | `v4` |
| `docker/metadata-action` | `v5` | `v6` |
| `docker/build-push-action` | `v6` | `v7` |

> **Note:** `astral-sh/setup-uv` must be pinned to an exact version (`v8.1.0`) because floating major/minor tags (`@v8`, `@v8.0`) were removed starting from v8.0.0.

#### SonarQube scan job (`test.yml`)

Adds a `sonarqube` job that runs after `tests` on push and pull request events. It downloads the coverage artifact produced by the Python 3.14 / Ubuntu run and feeds it to `SonarSource/sonarqube-scan-action@v7`.

Requires a `SONAR_TOKEN` secret to be configured in the repository settings.

#### Remove weekly scheduled run (`test.yml`)

The `schedule: cron: "0 7 * * 1"` trigger has been removed. Tests now only run on push, pull request, and manual dispatch.