### PR TITLE
fix: resolve SonarQube issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
         args: >
           -Dsonar.projectKey=cs-si_stac-fastapi-eodag
           -Dsonar.organization=cs-si
-          -Dsonar.python.version=3.14
+          -Dsonar.python.version=3.9
           -Dsonar.python.coverage.reportPaths=test-reports/coverage.xml
           -Dsonar.sources=stac_fastapi/
           -Dsonar.tests=tests/

--- a/stac_fastapi/eodag/errors.py
+++ b/stac_fastapi/eodag/errors.py
@@ -147,7 +147,7 @@ class ResponseSearchError(Exception):
         return 400
 
 
-async def eodag_errors_handler(request: Request, exc: Exception) -> JSONResponse:
+def eodag_errors_handler(request: Request, exc: Exception) -> JSONResponse:
     """Handler for EODAG errors"""
     code = EODAG_DEFAULT_STATUS_CODES.get(type(exc), getattr(exc, "status_code", 500)) or 500
     detail = f"{type(exc).__name__}: {str(exc)}"

--- a/stac_fastapi/eodag/utils.py
+++ b/stac_fastapi/eodag/utils.py
@@ -130,7 +130,7 @@ def check_poly_is_point(poly: Polygon) -> Union[Point, Polygon]:
     :returns: Either a `Point` or the unchanged `poly`.
     """
 
-    if poly.area == 0 and poly.area == 0 and poly.bounds[0] == poly.bounds[2] and poly.bounds[1] == poly.bounds[3]:
+    if poly.area == 0 and poly.bounds[0] == poly.bounds[2] and poly.bounds[1] == poly.bounds[3]:
         return Point(poly.exterior.coords[0])
     else:
         return poly


### PR DESCRIPTION
## fix: resolve SonarQube issues

### Changes

- **`utils.py`** — Remove duplicate `poly.area == 0` condition in `check_poly_is_point` (rule `python:S1764`: identical expressions on both sides of a binary operator)
- **`errors.py`** — Remove `async` keyword from `eodag_errors_handler` which contains no `await` calls (rule `python:S4457`)
- **`test.yml`** — Set `sonar.python.version=3.9` to match the minimum supported Python version, avoiding false positives on syntax valid only in 3.10+ (e.g. `X | Y` union expressions)