### PR TITLE
feat: add an explicit error for json in the filter for get request

### DIFF
--- a/stac_fastapi/eodag/core.py
+++ b/stac_fastapi/eodag/core.py
@@ -559,8 +559,8 @@ class EodagCoreClient(CustomCoreClient):
                     status_code=400,
                     detail=(
                         'The "filter" parameter provided in a GET request contains a JSON/dictionary object, '
-                        'which is not supported in the query string. Please use a POST request with a JSON body '
-                        'for this type of filter.'
+                        "which is not supported in the query string. Please use a POST request with a JSON body "
+                        "for this type of filter."
                     ),
                 )
 

--- a/stac_fastapi/eodag/core.py
+++ b/stac_fastapi/eodag/core.py
@@ -552,6 +552,18 @@ class EodagCoreClient(CustomCoreClient):
     ) -> dict[str, Any]:
         """Clean up search arguments to match format expected by pgstac"""
         if filter_expr:
+            # Reject filters containing JSON/dict-like payloads in GET requests.
+            # These complex filters must be sent as a POST with a JSON body.
+            if "{" in filter_expr or "}" in filter_expr:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        'The "filter" parameter provided in a GET request contains a JSON/dictionary object, '
+                        'which is not supported in the query string. Please use a POST request with a JSON body '
+                        'for this type of filter.'
+                    ),
+                )
+
             if filter_lang == "cql2-text":
                 filter_expr = to_cql2(parse_cql2_text(filter_expr))
                 filter_lang = "cql2-json"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -377,7 +377,7 @@ async def test_filter_extension_items(request_valid, defaults, mock_search):
 
 async def test_filter_extension_items_json_in_get_rejected(app_client, defaults):
     """Search through /items endpoint with JSON in GET filter should return a clear 400 error."""
-    filter_value = '%7B%22ecmwf:location%22%3A%7B%22longitude%22%3A100%2C%22latitude%22%3A0%7D%7D'
+    filter_value = "%7B%22ecmwf:location%22%3A%7B%22longitude%22%3A100%2C%22latitude%22%3A0%7D%7D"
     response = await app_client.get(
         f"/collections/{defaults.collection}/items?bbox={defaults.bbox_csv}&filter={filter_value}"
     )
@@ -387,8 +387,8 @@ async def test_filter_extension_items_json_in_get_rejected(app_client, defaults)
     assert resp_json["code"] == "400"
     assert resp_json["description"] == (
         'The "filter" parameter provided in a GET request contains a JSON/dictionary object, '
-        'which is not supported in the query string. Please use a POST request with a JSON body '
-        'for this type of filter.'
+        "which is not supported in the query string. Please use a POST request with a JSON body "
+        "for this type of filter."
     )
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -375,6 +375,23 @@ async def test_filter_extension_items(request_valid, defaults, mock_search):
     )
 
 
+async def test_filter_extension_items_json_in_get_rejected(app_client, defaults):
+    """Search through /items endpoint with JSON in GET filter should return a clear 400 error."""
+    filter_value = '%7B%22ecmwf:location%22%3A%7B%22longitude%22%3A100%2C%22latitude%22%3A0%7D%7D'
+    response = await app_client.get(
+        f"/collections/{defaults.collection}/items?bbox={defaults.bbox_csv}&filter={filter_value}"
+    )
+
+    assert response.status_code == 400
+    resp_json = response.json()
+    assert resp_json["code"] == "400"
+    assert resp_json["description"] == (
+        'The "filter" parameter provided in a GET request contains a JSON/dictionary object, '
+        'which is not supported in the query string. Please use a POST request with a JSON body '
+        'for this type of filter.'
+    )
+
+
 @pytest.mark.parametrize(
     "sortby,expected_sort_by",
     [


### PR DESCRIPTION
Add explicit validation for GET filter parameters containing JSON/dictionary objects and return a clear 400 error telling users to use POST with a JSON body for that kind of filter.