### PR TITLE
fix: add `downloadLink` asset independetly of the presence of `eodag:download_link`

### DIFF
--- a/stac_fastapi/eodag/models/item.py
+++ b/stac_fastapi/eodag/models/item.py
@@ -99,8 +99,12 @@ def create_stac_item(
             if origin:
                 asset["alternate"] = {"origin": origin}
 
+    is_product_online = (
+        properties.get("order:status", ONLINE_STATUS) == ONLINE_STATUS or provider in auto_order_whitelist
+    )
+
     # TODO: remove downloadLink asset after EODAG assets rework
-    if not any(asset_name.endswith(".parquet") for asset_name in assets):
+    if is_product_online and not any(asset_name.endswith(".parquet") for asset_name in assets):
         # eodag:download_link may be missing for some providers (e.g. planetary_computer)
         # but we still want to provide a download link for them when proxying is enabled.
         origin_href = properties.get("eodag:download_link")
@@ -112,7 +116,7 @@ def create_stac_item(
 
         if download_link:
             assets["downloadLink"] = {
-                "title": "Download link",
+                "title": "Full product download link",
                 "href": download_link,
                 "type": mime_type,
                 "roles": ["data"],

--- a/stac_fastapi/eodag/models/item.py
+++ b/stac_fastapi/eodag/models/item.py
@@ -96,29 +96,37 @@ def create_stac_item(
 
             asset["href"] = f"{asset_proxy_url}/{quote(asset_name)}"
             asset.pop("storage:refs", None)
-
             if origin:
                 asset["alternate"] = {"origin": origin}
 
     # TODO: remove downloadLink asset after EODAG assets rework
-    has_parquet_asset = any(asset_name.endswith(".parquet") for asset_name in assets)
-    if (download_link := properties.get("eodag:download_link")) and not has_parquet_asset:
-        origin_href = download_link
-        proxied_href = f"{asset_proxy_url}/downloadLink" if asset_proxy_url else origin_href
-        mime_type = guess_file_type(origin_href) or "application/octet-stream"
+    if not any(asset_name.endswith(".parquet") for asset_name in assets):
+        # eodag:download_link may be missing for some providers (e.g. planetary_computer)
+        # but we still want to provide a download link for them when proxying is enabled.
+        origin_href = properties.get("eodag:download_link")
+        download_link = f"{asset_proxy_url}/downloadLink" if asset_proxy_url else origin_href
 
-        download_asset = {"title": "Download link", "href": proxied_href, "type": mime_type, "roles": ["data"]}
+        mime_type = "application/octet-stream"
+        if origin_href:
+            mime_type = guess_file_type(origin_href) or mime_type
 
-        if asset_proxy_url and keep_origin_url and not origin_href.startswith(origin_url_blacklist):
-            download_asset["alternate"] = {
+        if download_link:
+            assets["downloadLink"] = {
+                "title": "Download link",
+                "href": download_link,
+                "type": mime_type,
+                "roles": ["data"],
+            }
+
+        # origin_href (a.k.a. eodag:download_link) may be missing for some providers (e.g. planetary_computer)
+        if download_link and origin_href and keep_origin_url and not origin_href.startswith(origin_url_blacklist):
+            assets["downloadLink"]["alternate"] = {
                 "origin": {
                     "title": "Origin asset link",
                     "href": origin_href,
                     "type": mime_type,
                 },
             }
-
-        assets["downloadLink"] = download_asset
 
     # filter properties we do not want to expose
     feature["properties"] = {k: v for k, v in properties.items() if not k.startswith("eodag:")}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -250,6 +250,34 @@ async def test_downloadlink_excluded_when_parquet_asset(request_valid, defaults,
     assert "downloadLink" in res[1]["assets"], "downloadLink should be present when no parquet assets"
 
 
+async def test_downloadlink_present_when_eodag_download_link_missing(request_valid, defaults, mock_search_result):
+    """downloadLink should be present when eodag:download_link is missing"""
+    search_result = mock_search_result
+
+    # Remove eodag:download_link from first product
+    search_result[0].properties.pop("eodag:download_link")
+
+    # Make sure second product is ONLINE to have assets
+    search_result[1].properties["order:status"] = ONLINE_STATUS
+
+    resp_json = await request_valid(f"search?collections={defaults.collection}", search_result=search_result)
+    res = resp_json["features"]
+
+    # First product does *not* have eodag:download_link, but downloadLink should still be created
+    assert "downloadLink" in res[0]["assets"], "downloadLink should be present also when eodag:download_link is missing"
+    assert (
+        res[0]["assets"]["downloadLink"]["href"]
+        == f"http://testserver/data/cop_dataspace/{res[0]['collection']}/{res[0]['id']}/downloadLink"
+    )
+
+    # Second product has eodag:download_link, so downloadLink should be present
+    assert "downloadLink" in res[1]["assets"], "downloadLink should be present when eodag:download_link exists"
+    assert (
+        res[1]["assets"]["downloadLink"]["href"]
+        == f"http://testserver/data/cop_dataspace/{res[1]['collection']}/{res[1]['id']}/downloadLink"
+    )
+
+
 async def test_not_found(request_not_found):
     """A request to eodag server with a not supported product type must return a 404 HTTP error code"""
     await request_not_found("search?collections=ZZZ&bbox=0,43,1,44")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -197,8 +197,8 @@ async def test_items_response(request_valid, defaults):
 
 async def test_assets_with_different_download_base_url(request_valid, defaults):
     """Domain for download links should be as configured in settings"""
-    settings = get_settings()
-    settings.download_base_url = "http://otherserver/"
+    download_base_url = get_settings().download_base_url
+    get_settings().download_base_url = "http://otherserver/"
     resp_json = await request_valid(
         f"search?collections={defaults.collection}",
     )
@@ -210,6 +210,9 @@ async def test_assets_with_different_download_base_url(request_valid, defaults):
         res[0]["assets"]["asset1"]["href"]
         == f"http://otherserver/data/cop_dataspace/{res[0]['collection']}/{res[0]['id']}/asset1"
     )
+
+    # restore the original download_base_url setting
+    get_settings().download_base_url = download_base_url
 
 
 async def test_no_invalid_symbols_in_urls(request_valid, defaults, mock_search_result):


### PR DESCRIPTION
The `downloadLink` asset should be shown for all providers (except some specific asset types). The product must be online to have a download link, i.e. it's not added if the product is on staging or offline. If `eodag:download_link` is missing, the proxy link is used if available.