### PR TITLE
fix: remove federation extension link as it is not valid

### DIFF
--- a/stac_fastapi/eodag/client.py
+++ b/stac_fastapi/eodag/client.py
@@ -53,6 +53,4 @@ class CustomCoreClient(AsyncBaseCoreClient):
         federation_dict = {fb: get_federation_backend_dict(request, fb) for fb in federation_backends}
         landing_page["federation"] = federation_dict
 
-        landing_page["stac_extensions"].append(self.stac_metadata_model._conformance_classes["FederationExtension"])
-
         return landing_page

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,6 +29,9 @@ async def test_landing_page(request_valid):
         "url": "https://dataspace.copernicus.eu",
     }
     assert len(response["federation"]) > 1
+    assert all(isinstance(ext, str) and ext for ext in response["stac_extensions"]), (
+        "stac_extensions must only contain non-empty strings (no null)"
+    )
 
 
 async def test_forward(app_client):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.15'",


### PR DESCRIPTION
The `stac_extensions` field must only contain non-empty strings per the STAC spec. This regression test ensures no null or empty values are ever returned in the landing page response.

Fix: https://github.com/CS-SI/stac-fastapi-eodag/issues/114

~En attente de: https://github.com/CS-SI/eodag/pull/2272~ After discussion, we decided to not include the extension link until OpenEO provides valid extension links.

cf: https://github.com/Open-EO/openeo-api/issues/598