### PR TITLE
chore: fix mypy arg-type errors for get_metadata_path_value in data_download

### DIFF
--- a/stac_fastapi/eodag/extensions/data_download.py
+++ b/stac_fastapi/eodag/extensions/data_download.py
@@ -154,22 +154,18 @@ class BaseDataDownloadClient:
             # (the same one as order ID) to make error message clearer
             product.properties["title"] = product.properties["id"]
             # "orderLink" property is set to auth provider conf matching url to create its auth plugin
-            status_link_metadata = cast(
-                Union[str, list[Union[str, None]]],
-                product.downloader.config.order_on_response["metadata_mapping"]["eodag:status_link"],
-            )
+            status_link_metadata = product.downloader.config.order_on_response["metadata_mapping"]["eodag:status_link"]
             product.properties["eodag:order_link"] = product.properties["eodag:status_link"] = get_metadata_path_value(
-                status_link_metadata
+                status_link_metadata  # type: ignore[arg-type]
             ).format(orderId=item_id)
 
-            search_link_metadata = cast(
-                Optional[Union[str, list[Union[str, None]]]],
-                product.downloader.config.order_on_response["metadata_mapping"].get("eodag:search_link"),
+            search_link_metadata = product.downloader.config.order_on_response["metadata_mapping"].get(
+                "eodag:search_link"
             )
             if search_link_metadata:
-                product.properties["eodag:search_link"] = get_metadata_path_value(search_link_metadata).format(
-                    orderId=item_id
-                )
+                product.properties["eodag:search_link"] = get_metadata_path_value(
+                    search_link_metadata  # type: ignore[arg-type]
+                ).format(orderId=item_id)
 
             order_status_method = getattr(product.downloader, "_order_status", None)
             if not order_status_method:

--- a/stac_fastapi/eodag/extensions/data_download.py
+++ b/stac_fastapi/eodag/extensions/data_download.py
@@ -154,12 +154,14 @@ class BaseDataDownloadClient:
             # (the same one as order ID) to make error message clearer
             product.properties["title"] = product.properties["id"]
             # "orderLink" property is set to auth provider conf matching url to create its auth plugin
-            status_link_metadata: Union[str, list[Union[str, None]]] = product.downloader.config.order_on_response["metadata_mapping"]["eodag:status_link"]
+            status_link_metadata: Union[str, list[Union[str, None]]]
+            status_link_metadata = product.downloader.config.order_on_response["metadata_mapping"]["eodag:status_link"]
             product.properties["eodag:order_link"] = product.properties["eodag:status_link"] = get_metadata_path_value(
                 status_link_metadata
             ).format(orderId=item_id)
 
-            search_link_metadata: Optional[Union[str, list[Union[str, None]]]] = product.downloader.config.order_on_response["metadata_mapping"].get(
+            search_link_metadata: Optional[Union[str, list[Union[str, None]]]]
+            search_link_metadata = product.downloader.config.order_on_response["metadata_mapping"].get(
                 "eodag:search_link"
             )
             if search_link_metadata:

--- a/stac_fastapi/eodag/extensions/data_download.py
+++ b/stac_fastapi/eodag/extensions/data_download.py
@@ -154,12 +154,12 @@ class BaseDataDownloadClient:
             # (the same one as order ID) to make error message clearer
             product.properties["title"] = product.properties["id"]
             # "orderLink" property is set to auth provider conf matching url to create its auth plugin
-            status_link_metadata = product.downloader.config.order_on_response["metadata_mapping"]["eodag:status_link"]
+            status_link_metadata: Union[str, list[Union[str, None]]] = product.downloader.config.order_on_response["metadata_mapping"]["eodag:status_link"]
             product.properties["eodag:order_link"] = product.properties["eodag:status_link"] = get_metadata_path_value(
                 status_link_metadata
             ).format(orderId=item_id)
 
-            search_link_metadata = product.downloader.config.order_on_response["metadata_mapping"].get(
+            search_link_metadata: Optional[Union[str, list[Union[str, None]]]] = product.downloader.config.order_on_response["metadata_mapping"].get(
                 "eodag:search_link"
             )
             if search_link_metadata:

--- a/stac_fastapi/eodag/extensions/data_download.py
+++ b/stac_fastapi/eodag/extensions/data_download.py
@@ -154,15 +154,17 @@ class BaseDataDownloadClient:
             # (the same one as order ID) to make error message clearer
             product.properties["title"] = product.properties["id"]
             # "orderLink" property is set to auth provider conf matching url to create its auth plugin
-            status_link_metadata: Union[str, list[Union[str, None]]]
-            status_link_metadata = product.downloader.config.order_on_response["metadata_mapping"]["eodag:status_link"]
+            status_link_metadata = cast(
+                Union[str, list[Union[str, None]]],
+                product.downloader.config.order_on_response["metadata_mapping"]["eodag:status_link"],
+            )
             product.properties["eodag:order_link"] = product.properties["eodag:status_link"] = get_metadata_path_value(
                 status_link_metadata
             ).format(orderId=item_id)
 
-            search_link_metadata: Optional[Union[str, list[Union[str, None]]]]
-            search_link_metadata = product.downloader.config.order_on_response["metadata_mapping"].get(
-                "eodag:search_link"
+            search_link_metadata = cast(
+                Optional[Union[str, list[Union[str, None]]]],
+                product.downloader.config.order_on_response["metadata_mapping"].get("eodag:search_link"),
             )
             if search_link_metadata:
                 product.properties["eodag:search_link"] = get_metadata_path_value(search_link_metadata).format(


### PR DESCRIPTION
Fix two mypy `arg-type` errors at lines 159 and 166 in `data_download.py`.\n\nThe variables `status_link_metadata` and `search_link_metadata` were inferred as `str | list[str]`, but `get_metadata_path_value` expects `str | list[str | None]`. Since Python's type system treats `list` as invariant, `list[str]` is not assignable to `list[str | None]`. Adding explicit type annotations widens the type to match the expected signature.