### PR TITLE
fix: search by ID of ordered product must contain the original search parameters

### DIFF
--- a/stac_fastapi/eodag/models/item.py
+++ b/stac_fastapi/eodag/models/item.py
@@ -30,6 +30,7 @@ from stac_pydantic.shared import Asset
 
 from eodag.api.product._product import EOProduct
 from eodag.api.product.metadata_mapping import OFFLINE_STATUS, ONLINE_STATUS
+from eodag.plugins.search.build_search_result import END, START, ecmwf_temporal_to_eodag
 from eodag.utils import deepcopy, guess_file_type
 from stac_fastapi.eodag.config import Settings, get_settings
 from stac_fastapi.eodag.errors import MisconfiguredError
@@ -153,8 +154,7 @@ def create_stac_item(
     feature["properties"] = {k: v for k, v in product_dict["properties"].items() if not k.startswith("eodag:")}
     feature["properties"].pop("qs", None)
     # add eodag request parameters to properties
-    eodag_request_params = product_dict["properties"].get("eodag:request_params", {})
-    eodag_request_params = {f"ecmwf:{k}": v for k, v in eodag_request_params.items()}
+    eodag_request_params = _extract_eodag_request_params(product)
     feature["properties"].update(eodag_request_params)
 
     feature["stac_extensions"] = product_dict["stac_extensions"]
@@ -187,3 +187,23 @@ def create_stac_item(
     ).get_links(extensions=extension_names, extra_links=feature.get("links"), request_json=request_json)
 
     return feature
+
+
+def _extract_eodag_request_params(
+    product: EOProduct,
+) -> dict[str, Any]:
+    """Extract EODAG request parameters from an EOProduct"""
+    product_dict = product.as_dict()
+    eodag_request_params = product_dict["properties"].get("eodag:request_params", {})
+    eodag_request_params.pop("area", None)
+    eodag_request_params.pop("location", None)
+    start_datetime, end_datetime = ecmwf_temporal_to_eodag(eodag_request_params)
+    eodag_request_params = {f"ecmwf:{k}": v for k, v in eodag_request_params.items()}
+    datetime_value = start_datetime or end_datetime
+    if datetime_value:
+        eodag_request_params["datetime"] = datetime_value
+    if start_datetime:
+        eodag_request_params[START] = start_datetime
+    if end_datetime:
+        eodag_request_params[END] = end_datetime
+    return eodag_request_params

--- a/stac_fastapi/eodag/models/item.py
+++ b/stac_fastapi/eodag/models/item.py
@@ -152,6 +152,10 @@ def create_stac_item(
     # filter properties we do not want to expose
     feature["properties"] = {k: v for k, v in product_dict["properties"].items() if not k.startswith("eodag:")}
     feature["properties"].pop("qs", None)
+    # add eodag request parameters to properties
+    eodag_request_params = product_dict["properties"].get("eodag:request_params", {})
+    eodag_request_params = {f"ecmwf:{k}": v for k, v in eodag_request_params.items()}
+    feature["properties"].update(eodag_request_params)
 
     feature["stac_extensions"] = product_dict["stac_extensions"]
 

--- a/stac_fastapi/eodag/models/item.py
+++ b/stac_fastapi/eodag/models/item.py
@@ -79,6 +79,13 @@ def create_stac_item(
     collection_obj = request.app.state.dag.collections_config.get(product.collection)
     collection = collection_obj.id if collection_obj else product.collection
 
+    # add eodag request parameters to properties
+    eodag_request_params = _extract_eodag_request_params(product)
+    product.properties.update(eodag_request_params)
+    eodag_geometry = _extract_eodag_geometry(product)
+    if eodag_geometry:
+        product.geometry = eodag_geometry
+
     feature = Item(
         type="Feature",
         assets={},
@@ -160,13 +167,6 @@ def create_stac_item(
     # filter properties we do not want to expose
     feature["properties"] = {k: v for k, v in product_dict["properties"].items() if not k.startswith("eodag:")}
     feature["properties"].pop("qs", None)
-    # add eodag request parameters to properties
-    eodag_request_params = _extract_eodag_request_params(product)
-    feature["properties"].update(eodag_request_params)
-    eodag_geometry = _extract_eodag_geometry(product)
-    if eodag_geometry:
-        feature["geometry"] = eodag_geometry.__geo_interface__
-        feature["bbox"] = eodag_geometry.bounds
 
     feature["stac_extensions"] = product_dict["stac_extensions"]
 
@@ -204,8 +204,7 @@ def _extract_eodag_request_params(
     product: EOProduct,
 ) -> dict[str, Any]:
     """Extract EODAG request parameters from an EOProduct"""
-    product_dict = product.as_dict()
-    eodag_request_params = product_dict["properties"].get("eodag:request_params", {})
+    eodag_request_params = product.properties.get("eodag:request_params", {})
     eodag_request_params = deepcopy(eodag_request_params)
     eodag_request_params.pop("area", None)
     eodag_request_params.pop("location", None)
@@ -225,8 +224,7 @@ def _extract_eodag_geometry(
     product: EOProduct,
 ) -> Optional[BaseGeometry]:
     """Extract EODAG geometry from an EOProduct"""
-    product_dict = product.as_dict()
-    eodag_request_params = product_dict["properties"].get("eodag:request_params", {})
+    eodag_request_params = product.properties.get("eodag:request_params", {})
 
     geometry = None
     # ECMWF Polytope uses non-geojson structure for features

--- a/stac_fastapi/eodag/models/item.py
+++ b/stac_fastapi/eodag/models/item.py
@@ -22,6 +22,7 @@ from urllib.parse import quote, unquote_plus, urlparse
 
 import orjson
 from fastapi import Request
+from shapely.geometry.base import BaseGeometry
 from stac_fastapi.types.errors import NotFoundError
 from stac_fastapi.types.requests import get_base_url
 from stac_fastapi.types.stac import Item
@@ -31,7 +32,13 @@ from stac_pydantic.shared import Asset
 from eodag.api.product._product import EOProduct
 from eodag.api.product.metadata_mapping import OFFLINE_STATUS, ONLINE_STATUS
 from eodag.plugins.search.build_search_result import END, START, ecmwf_temporal_to_eodag
-from eodag.utils import deepcopy, guess_file_type
+from eodag.utils import (
+    deepcopy,
+    get_geometry_from_ecmwf_area,
+    get_geometry_from_ecmwf_feature,
+    get_geometry_from_ecmwf_location,
+    guess_file_type,
+)
 from stac_fastapi.eodag.config import Settings, get_settings
 from stac_fastapi.eodag.errors import MisconfiguredError
 from stac_fastapi.eodag.models.links import ItemLinks
@@ -156,6 +163,10 @@ def create_stac_item(
     # add eodag request parameters to properties
     eodag_request_params = _extract_eodag_request_params(product)
     feature["properties"].update(eodag_request_params)
+    eodag_geometry = _extract_eodag_geometry(product)
+    if eodag_geometry:
+        feature["geometry"] = eodag_geometry.__geo_interface__
+        feature["bbox"] = eodag_geometry.bounds
 
     feature["stac_extensions"] = product_dict["stac_extensions"]
 
@@ -195,6 +206,7 @@ def _extract_eodag_request_params(
     """Extract EODAG request parameters from an EOProduct"""
     product_dict = product.as_dict()
     eodag_request_params = product_dict["properties"].get("eodag:request_params", {})
+    eodag_request_params = deepcopy(eodag_request_params)
     eodag_request_params.pop("area", None)
     eodag_request_params.pop("location", None)
     start_datetime, end_datetime = ecmwf_temporal_to_eodag(eodag_request_params)
@@ -207,3 +219,24 @@ def _extract_eodag_request_params(
     if end_datetime:
         eodag_request_params[END] = end_datetime
     return eodag_request_params
+
+
+def _extract_eodag_geometry(
+    product: EOProduct,
+) -> Optional[BaseGeometry]:
+    """Extract EODAG geometry from an EOProduct"""
+    product_dict = product.as_dict()
+    eodag_request_params = product_dict["properties"].get("eodag:request_params", {})
+
+    geometry = None
+    # ECMWF Polytope uses non-geojson structure for features
+    if "feature" in eodag_request_params:
+        geometry = get_geometry_from_ecmwf_feature(eodag_request_params["feature"])
+    # bounding box in area format
+    if "area" in eodag_request_params:
+        geometry = get_geometry_from_ecmwf_area(eodag_request_params["area"])
+    # single location
+    if "location" in eodag_request_params:
+        geometry = get_geometry_from_ecmwf_location(eodag_request_params["location"])
+
+    return geometry

--- a/stac_fastapi/eodag/models/item.py
+++ b/stac_fastapi/eodag/models/item.py
@@ -206,6 +206,7 @@ def _extract_eodag_request_params(
     """Extract EODAG request parameters from an EOProduct"""
     eodag_request_params = product.properties.get("eodag:request_params", {})
     eodag_request_params = deepcopy(eodag_request_params)
+    eodag_request_params.pop("feature", None)
     eodag_request_params.pop("area", None)
     eodag_request_params.pop("location", None)
     start_datetime, end_datetime = ecmwf_temporal_to_eodag(eodag_request_params)

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -166,7 +166,24 @@ async def test_order_item_contains_request_params(request_valid, post_data):
         assert item["properties"][f"ecmwf:{key}"] == value
 
 
-async def test_order_item_contains_request_params_geom(request_valid):
+@pytest.mark.parametrize(
+    "post_data, expected_bbox, expected_geometry",
+    [
+        ({"area": [41, 10, 40, 11]}, [10, 40, 11, 41], [[10, 40], [10, 41], [11, 41], [11, 40], [10, 40]]),
+        (
+            {"location": {"longitude": 10, "latitude": 40}},
+            [10, 40, 10, 40],
+            [[10, 40], [10, 40], [10, 40], [10, 40]],
+            # [[10, 40],[10, 40],[11, 40],[11, 40],[10, 40]],
+        ),
+        (
+            {"feature": {"type": "polygon", "shape": [[40, 10], [41, 10], [41, 11], [40, 11], [40, 10]]}},
+            [10, 40, 11, 41],
+            [[10, 40], [10, 41], [11, 41], [11, 40], [10, 40]],
+        ),
+    ],
+)
+async def test_order_item_contains_request_params_geom(request_valid, post_data, expected_bbox, expected_geometry):
     """GET /collections/{id}/items/{item_id} of an ordered product must update
     the geometry and bbox attributes"""
     federation_backend = "cop_ads"
@@ -181,10 +198,6 @@ async def test_order_item_contains_request_params_geom(request_valid):
     )
     product.collection = collection_id
     product_id = product.properties["id"]
-    post_data = {
-        # area: [max_lat, min_lon, min_lat, max_lon]
-        "area": [41, 10, 40, 11],
-    }
 
     # store the original request parameters on the product, as the order endpoint would
     product.properties["eodag:request_params"] = post_data
@@ -206,24 +219,16 @@ async def test_order_item_contains_request_params_geom(request_valid):
         check_links=False,
     )
 
-    # bbox: [min_lon, min_lat, max_lon, max_lat]
-    assert item["bbox"] == [10, 40, 11, 41]
+    assert item["bbox"] == expected_bbox
     assert item["geometry"] == {
         "type": "Polygon",
-        "coordinates": [
-            [
-                [10, 40],
-                [10, 41],
-                [11, 41],
-                [11, 40],
-                [10, 40],
-            ]
-        ],
+        "coordinates": [expected_geometry],
     }
-    # the original request parameter "area" must not be present in properties
-    assert "area" not in item["properties"]
-    assert "ecmwf:area" not in item["properties"]
-    assert "ecmwf_area" not in item["properties"]
+    # the original request parameter must not be present in properties
+    for p in ("area", "location", "feature"):
+        assert p not in item["properties"]
+        assert f"ecmwf:{p}" not in item["properties"]
+        assert f"ecmwf_{p}" not in item["properties"]
 
 
 @pytest.mark.parametrize("post_data", [{"foo": "bar"}, {}])

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -125,6 +125,108 @@ async def test_order_ok(request_valid, post_data):
 
 
 @pytest.mark.parametrize("post_data", [{"foo": "bar"}, {}])
+async def test_order_item_contains_request_params(request_valid, post_data):
+    """GET /collections/{id}/items/{item_id} of an ordered product must contain
+    the original request parameters"""
+    federation_backend = "cop_ads"
+    collection_id = "CAMS_EAC4"
+    product = EOProduct(
+        federation_backend,
+        dict(
+            geometry="POINT (0 0)",
+            title="dummy_product",
+            id="dummy_id",
+        ),
+    )
+    product.collection = collection_id
+    product_id = product.properties["id"]
+
+    # store the original request parameters on the product, as the order endpoint would
+    product.properties["eodag:request_params"] = post_data
+
+    # order an offline product
+    product.properties["order:status"] = OFFLINE_STATUS
+
+    # GET the ordered item by ID and verify request params are present in properties
+    url = f"collections/{collection_id}/items/{product_id}"
+    item = await request_valid(
+        url=url,
+        method="GET",
+        search_result=SearchResult([product]),
+        expected_search_kwargs=dict(
+            collection=collection_id,
+            id=product_id,
+            validate=True,
+        ),
+        check_links=False,
+    )
+
+    # the item properties must contain the original request parameters, prefixed with "ecmwf:"
+    for key, value in post_data.items():
+        assert item["properties"][f"ecmwf:{key}"] == value
+
+
+async def test_order_item_contains_request_params_geom(request_valid):
+    """GET /collections/{id}/items/{item_id} of an ordered product must update
+    the geometry and bbox attributes"""
+    federation_backend = "cop_ads"
+    collection_id = "CAMS_EAC4"
+    product = EOProduct(
+        federation_backend,
+        dict(
+            geometry="POINT (0 0)",
+            title="dummy_product",
+            id="dummy_id",
+        ),
+    )
+    product.collection = collection_id
+    product_id = product.properties["id"]
+    post_data = {
+        # area: [max_lat, min_lon, min_lat, max_lon]
+        "area": [41, 10, 40, 11],
+    }
+
+    # store the original request parameters on the product, as the order endpoint would
+    product.properties["eodag:request_params"] = post_data
+
+    # order an offline product
+    product.properties["order:status"] = OFFLINE_STATUS
+
+    # GET the ordered item by ID and verify request params are present in properties
+    url = f"collections/{collection_id}/items/{product_id}"
+    item = await request_valid(
+        url=url,
+        method="GET",
+        search_result=SearchResult([product]),
+        expected_search_kwargs=dict(
+            collection=collection_id,
+            id=product_id,
+            validate=True,
+        ),
+        check_links=False,
+    )
+
+    # bbox: [min_lon, min_lat, max_lon, max_lat]
+    assert item["bbox"] == [10, 40, 11, 41]
+    assert item["geometry"] == {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [10, 40],
+                [10, 41],
+                [11, 41],
+                [11, 40],
+                [10, 40],
+            ]
+        ],
+    }
+    # the original request parameter "area" must not be present in properties
+    assert "area" not in item["properties"]
+    assert "ecmwf:area" not in item["properties"]
+    assert "ecmwf_area" not in item["properties"]
+
+
+@pytest.mark.parametrize("post_data", [{"foo": "bar"}, {}])
 async def test_order_with_poll_pending(request_valid, post_data):
     """Order a product through eodag server with a pending poll and check"
     if it has been ordered correctly and its status is on staging"""

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -124,7 +124,7 @@ async def test_order_ok(request_valid, post_data):
     await run()
 
 
-@pytest.mark.parametrize("post_data", [{"foo": "bar"}, {}])
+@pytest.mark.parametrize("post_data", [{"foo": "bar", "date": "2025-01-01/2025-01-31"}, {}])
 async def test_order_item_contains_request_params(request_valid, post_data):
     """GET /collections/{id}/items/{item_id} of an ordered product must contain
     the original request parameters"""
@@ -161,7 +161,14 @@ async def test_order_item_contains_request_params(request_valid, post_data):
         check_links=False,
     )
 
+    # "ecmwf:date" is mapped to "datetime", "start_datetime" and "end_datetime"
+    if "date" in post_data:
+        start_datetime, end_datetime = post_data["date"].split("/")
+        assert item["properties"]["datetime"] == start_datetime + "T00:00:00.000Z"
+        assert item["properties"]["start_datetime"] == start_datetime + "T00:00:00.000Z"
+        assert item["properties"]["end_datetime"] == end_datetime + "T00:00:00.000Z"
     # the item properties must contain the original request parameters, prefixed with "ecmwf:"
+    # this includes also "ecmwf:date"
     for key, value in post_data.items():
         assert item["properties"][f"ecmwf:{key}"] == value
 


### PR DESCRIPTION
The Copernicus providers return the search parameters in the order status request. The EODAG library stores them in the `eodag:request_params`. This PR gets the parameters from `eodag:request_params` and copy them in the item's properties.